### PR TITLE
removed `--credit-adddress` from `ya-provider run` arguments

### DIFF
--- a/test/level0/unix/start_provider.sh
+++ b/test/level0/unix/start_provider.sh
@@ -32,7 +32,6 @@ ya-provider --exe-unit-path "$EXE_UNIT_PATH" \
 	    run \
 	    --activity-url "$YAGNA_ACTIVITY_URL" \
 	    --app-key "$APP_KEY" \
-	    --credit-address "$NODE_ID" \
 	    --market-url "$YAGNA_MARKET_URL" \
 	    --node-name test-provider \
 	    "$PRESET_NAME"


### PR DESCRIPTION
as removed in https://github.com/golemfactory/yagna/pull/166

Kept the NODE_ID lookup even while its not used, the requestor script has the same unused variable