### PR TITLE
Set CENTRAL_MARKET_URL env var in containers. Revert to default network in docker compose.

### DIFF
--- a/src/docker/docker-compose.yml
+++ b/src/docker/docker-compose.yml
@@ -11,23 +11,8 @@ services:
                 GITHUB_API_TOKEN: $GITHUB_API_TOKEN
         entrypoint: /usr/bin/ya_sb_router
         command: ["-l", "tcp://0.0.0.0:7477"]
-        networks:
-            - test_network
 
     mock-api:
         image: golemfactory/golem-client-mock:0.1.2
-        environment:
-            - ASPNETCORE_URLS=http://*:8080
         ports:
-            - "8080:8080"
-        networks:
-            test_network:
-                ipv4_address: 34.244.4.185
-
-networks:
-
-    test_network:
-        ipam:
-            driver: default
-            config:
-                - subnet: 34.244.0.0/16
+            - "5001:5001"

--- a/src/runner/container.py
+++ b/src/runner/container.py
@@ -10,15 +10,13 @@ class YagnaContainer:
     COMMAND = ["service", "run", "-d", "/"]
     ENTRYPOINT = "/usr/bin/yagna"
     ENVIRONMENT = [
-        "YAGNA_BUS_PORT=6010",
-        "YAGNA_HTTP_PORT=6000",
+        "CENTRAL_MARKET_URL=http://mock-api:5001/market-api/v1/",
         "CENTRAL_NET_HOST=router:7477",
         "GSB_URL=tcp://0.0.0.0:6010",
         "YAGNA_API_URL=http://0.0.0.0:6000",
-        "YAGNA_ACTIVITY_URL=http://127.0.0.1:6000/activity-api/v1/",
     ]
     IMAGE_NAME = "yagna"
-    NETWORK_NAME = "docker_test_network"
+    NETWORK_NAME = "docker_default"
 
     # Keeps track of assigned ports on the Docker host
     port_offset = 0


### PR DESCRIPTION
This reverts changes in network configuration for docker compose from https://github.com/golemfactory/yagna-integration/pull/61

Location of market API is now set using the CENTRAL_MARKET_URL env var.


