### PR TITLE
Provide default assets in yagna image

### DIFF
--- a/src/docker/default/asset/agreement.json
+++ b/src/docker/default/asset/agreement.json
@@ -1,0 +1,22 @@
+{
+  "agreementId": "0a88ff65-b6d4-48e4-8de3-aba9f06f54dd",
+  "demand": {
+    "properties": {
+      "golem": {
+        "srv.comp.wasm": {
+          "task_package": "hash://sha3:38D951E2BD2408D95D8D5E5068A69C60C8238FA45DB8BC841DC0BD50:http://34.244.4.185:8000/rust-wasi-tutorial.zip"
+        },
+        "com.usage.vector": [
+          "golem.usage.duration_sec",
+          "golem.usage.cpu_sec"
+        ]
+      }
+    }
+  },
+  "offer": {
+    "properties.golem.inf": {
+      "mem.gib": 0.5,
+      "storage.gib": 5
+    }
+  }
+}

--- a/src/docker/default/asset/exe_script.json
+++ b/src/docker/default/asset/exe_script.json
@@ -1,0 +1,23 @@
+[
+  {"deploy": {
+  }},
+  {"start": {
+    "args": []
+  }},
+  {
+    "transfer": {
+      "from": "http://34.244.4.185:8000/LICENSE",
+      "to": "container:/input/file_in"
+    }
+  },
+  {"run": {
+    "entry_point": "rust-wasi-tutorial",
+    "args": ["/input/file_in", "/output/file_cp"]
+  }},
+  {
+    "transfer": {
+      "from": "container:/output/file_cp",
+      "to": "http://34.244.4.185:8000/upload/file_up"
+    }
+  }
+]

--- a/src/docker/default/asset/presets.json
+++ b/src/docker/default/asset/presets.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "lame-offer",
+    "exeunit-name": "wasmtime",
+    "pricing-model": "linear",
+    "usage-coeffs": [0.0, 0.0, 0.0]
+  },
+  {
+    "name": "high-cpu",
+    "exeunit-name": "wasmtime",
+    "pricing-model": "linear",
+    "usage-coeffs": [0.01, 1.2, 1.5]
+  },
+  {
+    "name": "amazing-offer",
+    "exeunit-name": "wasmtime",
+    "pricing-model": "linear",
+    "usage-coeffs": [0.1, 0.2, 1.0]
+  }
+]

--- a/src/docker/yagna.Dockerfile
+++ b/src/docker/yagna.Dockerfile
@@ -7,6 +7,8 @@ RUN pip install requests \
     && python ./download_release.py -t ${GITHUB_API_TOKEN} ya-runtime-wasi
 
 FROM ubuntu:20.04
+COPY default/asset /asset
+COPY default/asset/presets.json /presets.json
 COPY --from=downloader /yagna.deb /ya-sb-router.deb ya-runtime-wasi.deb ./
 RUN apt update && apt install -y ./yagna.deb ./ya-sb-router.deb ./ya-runtime-wasi.deb
 ENTRYPOINT /usr/bin/yagna

--- a/src/runner/__init__.py
+++ b/src/runner/__init__.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from itertools import chain
 import logging
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import docker
 
@@ -16,12 +16,12 @@ logger = logging.getLogger(__name__)
 class Runner:
 
     # Path to directory containing yagna assets which should be mounted in containers
-    assets_path: Path
+    assets_path: Optional[Path]
 
     # Probes used for the test run, identified by their role names
     probes: Dict[Role, List[Probe]]
 
-    def __init__(self, assets_path: Path):
+    def __init__(self, assets_path: Optional[Path]):
         self.assets_path = assets_path
         self.probes = defaultdict(list)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+from typing import Optional
+
 import pytest
 
 
@@ -8,12 +10,12 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture()
-def assets_path(request) -> Path:
+def assets_path(request) -> Optional[Path]:
     """ Test fixture which tries to get the value of CLI parameter --assets-path.
         If the value is not set, the test using this fixture will fail. """
     path = request.config.option.assets_path
     if not path:
-        pytest.fail("The CLI option --assets-path was not provided.")
+        return None
 
     path = Path(path)
     if not path.is_dir():

--- a/test/level0/test_level0.py
+++ b/test/level0/test_level0.py
@@ -2,6 +2,7 @@ import logging
 from pathlib import Path
 import re
 from string import Template
+from typing import Optional
 
 from src.runner import Runner
 from src.runner.container.yagna import YagnaContainerConfig
@@ -136,5 +137,5 @@ class Level0Scenario(Scenario):
 
 
 class TestLevel0:
-    def test_level0(self, assets_path: Path):
+    def test_level0(self, assets_path: Optional[Path]):
         Runner(assets_path).run(Level0Scenario(use_proxy=True))


### PR DESCRIPTION
TL;DR
- Include the current assets directory (from `test/level0/asset`) in the yagna Docker image (see `docker/yagna.Dockerfile`).
- Make `--assets-path` CLI argument to `pytest` optional. If provided, the given assets will override default ones included in the yagna container.