### PR TITLE
Tweaking the script to run on Docker for Windows

### DIFF
--- a/src/api_monitor/start-proxy.sh
+++ b/src/api_monitor/start-proxy.sh
@@ -15,6 +15,6 @@ mitmdump --mode reverse:"http://127.0.0.1" \
     -s ./router_addon.py \
     -s ./monitor_addon.py \
     --set assertions=assertions.level0_assertions
-# This script must end with a line not terminated with "\n",
+# This script must not end with an empty line,
 # otherwise it won't work in Docker on Windows.
 # Do not modify this line!


### PR DESCRIPTION
The mitmproxy caused following error under Docker for Windows:

standard_init_linux.go:211: exec user process caused "no such file or directory"

The empty line at the end of the script seems to be triggering this. The error disappears when the newline is removed.