### PR TITLE
Make the method `EventMonitor.add_event()` synchronous

### DIFF
--- a/src/api_monitor/monitor_addon.py
+++ b/src/api_monitor/monitor_addon.py
@@ -95,7 +95,7 @@ class MonitorAddon:
         if assertions_module is not None:
             self.monitor.load_assertions(assertions_module)
         self.monitor.start()
-        self.monitor.schedule_add_event(APIClockTick())
+        self.monitor.add_event(APIClockTick())
 
         timer_thread = threading.Thread(
             target=self._timer, name="Timer thread", daemon=True
@@ -107,12 +107,12 @@ class MonitorAddon:
 
         logger.debug("Timer thread started")
         while not self.monitor.is_running():
-            self.monitor.schedule_add_event(APIClockTick())
+            self.monitor.add_event(APIClockTick())
             time.sleep(1.0)
 
     def _register_event(self, event: APIEvent) -> None:
         _log_event(event)
-        self.monitor.schedule_add_event(event)
+        self.monitor.add_event(event)
 
     def request(self, flow: HTTPFlow) -> None:
         """Register a request"""

--- a/test/assertions/test_monitor.py
+++ b/test/assertions/test_monitor.py
@@ -73,7 +73,7 @@ async def test_assertions():
     monitor.start()
 
     for n in [1, 3, 4, 6, 3, 8, 9, 10]:
-        await monitor.add_event(n)
+        monitor.add_event(n)
 
     await monitor.stop()
 
@@ -91,7 +91,7 @@ async def test_not_started_raises_on_add_event():
     monitor: EventMonitor[int] = EventMonitor()
 
     with pytest.raises(RuntimeError):
-        await monitor.add_event(1)
+        monitor.add_event(1)
 
 
 @pytest.mark.asyncio
@@ -104,4 +104,4 @@ async def test_stopped_raises_on_add_event():
     await monitor.stop()
 
     with pytest.raises(RuntimeError):
-        await monitor.add_event(1)
+        monitor.add_event(1)


### PR DESCRIPTION
The method `EventMonitor.add_event(event)` is used to register a new event in an event monitor. The only thing it does is to insert the new event into the `asyncio.Queue`, so that it can be processed asynchronously by the worker task. 

This PR replaces asynchronous calls to `asyncio.Queue.put` with synchronous calls to `asyncio.Queue.put_nowait`, as there's no need for the activity of inserting the event into the queue to be performed in an asynchronous manner.

As a result, the method `EventMonitor.add_event(event)` becomes synchronous (again), which is a good thing!

And the events are still processed asynchronously by the assertions running in the monitor.