### PR TITLE
Start assertions in `EventMonitor.add_assertions`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         run: docker ps
 
       - name: Run unit tests
-        run: python -m pytest test/runner -svx
+        run: python -m pytest test/assertions test/runner -svx
 
       - name: Run test suite
         run: python -m pytest test/level0 -svx --log-cli-level=DEBUG --assets-path test/level0/asset

--- a/src/assertions/monitor.py
+++ b/src/assertions/monitor.py
@@ -42,9 +42,10 @@ class EventMonitor(Generic[E]):
     def add_assertions(self, assertion_funcs: List[AssertionFunction[E]]) -> None:
         """Add a list of assertion functions to this monitor."""
 
-        self.assertions.extend(
-            Assertion(self._events, func) for func in assertion_funcs
-        )
+        for func in assertion_funcs:
+            assertion = Assertion(self._events, func)
+            assertion.start()
+            self.assertions.append(assertion)
 
     def load_assertions(self, module_name: str) -> None:
         """Load assertion functions from a module."""
@@ -58,6 +59,7 @@ class EventMonitor(Generic[E]):
         """Start tracing events."""
 
         self._worker_task = asyncio.create_task(self._run_worker())
+        logger.info("Monitor started")
 
     def add_event(self, event: E) -> None:
         """Register a new event."""


### PR DESCRIPTION
Probably due to a bad merge, assertions added to an `EventMonitor` are never started, which causes exceptions in the worker task (the task that checks assertions) in the monitor.

This PR starts the assertions in `EventMonitor.add_assertions` method, which is the only method for adding assertions to the monitor.

This PR also enables unit tests in the `test/assertions` directory, which would have detected this issue if they had been enabled.