### PR TITLE
Include assertions module in `api-monitor` image built during tests

### DIFF
--- a/docker/api-monitor.Dockerfile
+++ b/docker/api-monitor.Dockerfile
@@ -1,5 +1,7 @@
 FROM mitmproxy/mitmproxy:5.1.1
 
+ARG ASSERTIONS_PATH
+
 RUN apk add --no-cache nginx \
     && mkdir -p /run/nginx
 
@@ -9,6 +11,8 @@ COPY goth/api_monitor/*.py \
      goth/api_monitor/nginx.conf \
      goth/api_monitor/start-proxy.sh \
      /goth/api_monitor/
+
+COPY ${ASSERTIONS_PATH} /assertions
 
 WORKDIR /goth/api_monitor
 


### PR DESCRIPTION
Resolves #130 (see the description of this issue for details)

IMO, this PR is a work-around for an issue arising when running github workflows locally with a particular tool, rather than an implementation of a useful feature.

I think we should have the possibility of mounting host directories to containers run during integration tests. Since we may instantiate multiple requestor, provider and proxy containers in a single test, it could be convenient to mount a separate host directory to each container, instead of including common test assets and assertions in `yagna` and `api-monitor` docker images. 