### PR TITLE
Split CENTRAL_MARKET_URL from YAGNA_MARKET_URL

### DIFF
--- a/test/level0/unix/provider.env
+++ b/test/level0/unix/provider.env
@@ -11,10 +11,10 @@ MARKET_URL_BASE=http://127.0.0.1:5001
 GSB_URL=tcp://127.0.0.1:6011
 YAGNA_API_URL=http://127.0.0.1:6001
 
-if [ -n "$USE_PROXY" ]; then    
+if [ -n "$USE_PROXY" ]; then
     # Proxy mode: daemon and agent connect to market API
     # through proxy (using distinct ports); agent connects
-    # to daemon through proxy 
+    # to daemon through proxy
     if [ -n "$AGENT" ]; then
         MARKET_URL_BASE=http://127.0.0.1:15004
         YAGNA_API_URL=http://127.0.0.1:16001
@@ -24,5 +24,5 @@ if [ -n "$USE_PROXY" ]; then
 fi
 
 YAGNA_ACTIVITY_URL=${YAGNA_API_URL}/activity-api/v1/
-YAGNA_MARKET_URL=${MARKET_URL_BASE}/market-api/v1/
-
+YAGNA_MARKET_URL=${YAGNA_API_URL}/market-api/v1/
+CENTRAL_MARKET_URL=${MARKET_URL_BASE}/market-api/v1/

--- a/test/level0/unix/requestor.env
+++ b/test/level0/unix/requestor.env
@@ -11,10 +11,10 @@ MARKET_URL_BASE=http://127.0.0.1:5001
 GSB_URL=tcp://127.0.0.1:6010
 YAGNA_API_URL=http://127.0.0.1:6000
 
-if [ -n "$USE_PROXY" ]; then    
+if [ -n "$USE_PROXY" ]; then
     # Proxy mode: daemon and agent connect to market API
     # through proxy (using distinct ports); agent connects
-    # to daemon through proxy 
+    # to daemon through proxy
     if [ -n "$AGENT" ]; then
         MARKET_URL_BASE=http://127.0.0.1:15002
         YAGNA_API_URL=http://127.0.0.1:16000
@@ -24,4 +24,5 @@ if [ -n "$USE_PROXY" ]; then
 fi
 
 YAGNA_ACTIVITY_URL=${YAGNA_API_URL}/activity-api/v1/
-YAGNA_MARKET_URL=${MARKET_URL_BASE}/market-api/v1/
+YAGNA_MARKET_URL=${YAGNA_API_URL}/market-api/v1/
+CENTRAL_MARKET_URL=${MARKET_URL_BASE}/market-api/v1/


### PR DESCRIPTION
This was already updated in the level0 python test, now also available in the level0/unix tests :D