### PR TITLE
Fix payment API client init

### DIFF
--- a/goth/runner/probe.py
+++ b/goth/runner/probe.py
@@ -213,7 +213,7 @@ class RequestorProbe(Probe):
         config = payment.Configuration(host=api_url)
         config.access_token = self.app_key
         client = payment.ApiClient(config)
-        self.payment = payment.RequestorApi(config)
+        self.payment = payment.RequestorApi(client)
         self._logger.debug(
             "payment API initialized. node_name=%s, url=%s", self.name, api_url
         )


### PR DESCRIPTION
An oversight from #133, the payment API client in the requestor probe was not being initialised properly.