### PR TITLE
Raise exceptions as they happen in steps

### DIFF
--- a/goth/assertions/monitor.py
+++ b/goth/assertions/monitor.py
@@ -85,7 +85,7 @@ class EventMonitor(Generic[E]):
 
         self._incoming.put_nowait(event)
 
-    async def await_assertions(self, timeout: timedelta = timedelta(seconds=10)):
+    async def await_assertions(self, timeout: timedelta = timedelta(seconds=60)):
         """Sleep until all assertions are done or the timeout passed."""
 
         if not self.is_running():
@@ -95,6 +95,7 @@ class EventMonitor(Generic[E]):
 
         while not self.finished:
             if deadline < datetime.now():
+                print("TIMEOUT!!!")
                 raise TimeoutError
             await asyncio.sleep(0.1)
 

--- a/goth/runner/__init__.py
+++ b/goth/runner/__init__.py
@@ -85,7 +85,7 @@ class Runner:
                     if result:
                         awaitables.append(result)
                 if awaitables:
-                    await asyncio.gather(*awaitables, return_exceptions=True)
+                    await asyncio.gather(*awaitables)
 
                 self.check_assertion_errors()
 


### PR DESCRIPTION
Quick fix to raise exceptions as they happen in tests.

Alternative/upgrade is to:
- handle the result of `asyncio.gather`, so all tasks finish
- cancel other running coroutines in finally