### PR TITLE
Added error printing when APIError occurs

### DIFF
--- a/goth/api_monitor/api_events.py
+++ b/goth/api_monitor/api_events.py
@@ -118,6 +118,9 @@ class APIError(APIEvent):
         """Time of the error."""
         return self.error.timestamp
 
+    def __str__(self):
+        return f"{self.request} -> {self.error}"
+
 
 def _match_event(
     event: APIEvent,

--- a/goth/assertions/common.py
+++ b/goth/assertions/common.py
@@ -19,7 +19,7 @@ async def assert_no_api_errors(stream: APIEvents) -> bool:
     async for e in stream:
 
         if isinstance(e, APIError):
-            raise TemporalAssertionError("API error occurred")
+            raise TemporalAssertionError(f"API error occurred: {e}")
 
     return True
 

--- a/test/level0/assertions/level0_assertions.py
+++ b/test/level0/assertions/level0_assertions.py
@@ -7,13 +7,11 @@ from goth.api_monitor.api_events import APIResponse
 import goth.api_monitor.api_events as api
 
 from goth.assertions import AssertionFunction, TemporalAssertionError
-from goth.assertions.operators import eventually
-
-from .common_assertions import (
+from goth.assertions.common import (
     APIEvents,
     assert_no_api_errors,
 )
-
+from goth.assertions.operators import eventually
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Moved common_assertions to `goth` for re-use in level1