### PR TITLE
Replace Role enum with typing setup

### DIFF
--- a/goth/runner/probe.py
+++ b/goth/runner/probe.py
@@ -1,11 +1,10 @@
 """Classes and helpers for managing Probes."""
 
 import abc
-from enum import Enum
 import logging
 from pathlib import Path
 import time
-from typing import Optional
+from typing import Optional, Type
 
 from docker import DockerClient
 
@@ -28,13 +27,6 @@ from goth.runner.log import LogConfig
 from goth.runner.log_monitor import LogEventMonitor
 
 logger = logging.getLogger(__name__)
-
-
-class Role(Enum):
-    """Role of the probe."""
-
-    requestor = 0
-    provider = 1
 
 
 class ProbeLoggingAdapter(logging.LoggerAdapter):
@@ -295,3 +287,8 @@ class ProviderProbe(Probe):
         if self.agent_logs is not None:
             await self.agent_logs.stop()
         await super().stop()
+
+
+Provider = ProviderProbe
+Requestor = RequestorProbe
+Role = Type[Probe]

--- a/test/level0/test_level0.py
+++ b/test/level0/test_level0.py
@@ -21,7 +21,7 @@ from goth.address import (
 from goth.runner import Runner
 
 from goth.runner.container.yagna import YagnaContainerConfig
-from goth.runner.probe import Role
+from goth.runner.probe import Provider, Requestor
 
 logger = logging.getLogger(__name__)
 
@@ -62,13 +62,13 @@ VOLUMES = {
 LEVEL0_TOPOLOGY = [
     YagnaContainerConfig(
         name="requestor",
-        role=Role.requestor,
+        role=Requestor,
         environment=node_environment(),
         volumes=VOLUMES,
     ),
     YagnaContainerConfig(
         name="provider_1",
-        role=Role.provider,
+        role=Provider,
         # Configure this provider node to communicate via proxy
         environment=node_environment(
             market_url_base=MARKET_BASE_URL.substitute(host=PROXY_HOST),
@@ -78,7 +78,7 @@ LEVEL0_TOPOLOGY = [
     ),
     YagnaContainerConfig(
         name="provider_2",
-        role=Role.provider,
+        role=Provider,
         # Configure the second provider node to communicate via proxy
         environment=node_environment(
             market_url_base=MARKET_BASE_URL.substitute(host=PROXY_HOST),
@@ -99,7 +99,7 @@ class TestLevel0:
             LEVEL0_TOPOLOGY, "assertions.level0_assertions", logs_path, assets_path
         )
 
-        all_providers = runner.get_probes_by_role(Role.provider)
+        all_providers = runner.get_probes(role=Provider)
 
         all_providers.wait_for_offer_subscribed()
         all_providers.wait_for_proposal_accepted()

--- a/test/level1/test_level1.py
+++ b/test/level1/test_level1.py
@@ -21,7 +21,7 @@ from goth.address import (
 from goth.runner import Runner
 
 from goth.runner.container.yagna import YagnaContainerConfig
-from goth.runner.probe import Role
+from goth.runner.probe import Provider, Requestor
 
 logger = logging.getLogger(__name__)
 
@@ -63,13 +63,13 @@ VOLUMES = {
 LEVEL1_TOPOLOGY = [
     YagnaContainerConfig(
         name="requestor",
-        role=Role.requestor,
+        role=Requestor,
         environment=node_environment(),
         volumes=VOLUMES,
     ),
     YagnaContainerConfig(
         name="provider_1",
-        role=Role.provider,
+        role=Provider,
         # Configure this provider node to communicate via proxy
         environment=node_environment(
             market_url_base=MARKET_BASE_URL.substitute(host=PROXY_HOST),
@@ -79,7 +79,7 @@ LEVEL1_TOPOLOGY = [
     ),
     # YagnaContainerConfig(
     #     name="provider_2",
-    #     role=Role.provider,
+    #     role=Provider,
     #     # Configure the second provider node to communicate via proxy
     #     environment=node_environment(
     #         market_url_base=MARKET_BASE_URL.substitute(host=PROXY_HOST),
@@ -100,8 +100,8 @@ class TestLevel1:
             LEVEL1_TOPOLOGY, "assertions.level1_assertions", logs_path, assets_path
         )
 
-        provider = runner.get_probes_by_role(Role.provider)
-        requestor = runner.get_probes_by_role(Role.requestor)
+        provider = runner.get_probes(role=Provider)
+        requestor = runner.get_probes(role=Requestor)
 
         requestor.init_payment()
 


### PR DESCRIPTION
Resolves: #173

Replaces the Role enum with a Type definition, along with aliases for
provider and requestor probe types.

Blocked by: #175 (test run is failing on payment init)