### PR TITLE
Stop agent logs in `Probe.stop()`

### DIFF
--- a/goth/runner/probe.py
+++ b/goth/runner/probe.py
@@ -132,8 +132,10 @@ class Probe(abc.ABC):
 
         Once stopped, a probe cannot be restarted.
         """
-        if self.container.logs is not None:
+        if self.container.logs:
             await self.container.logs.stop()
+        if self.agent_logs:
+            await self.agent_logs.stop()
         self.container.remove(force=True)
 
 


### PR DESCRIPTION
This is to remove that annoying stack trace printed when the test finishes, due to the agent log monitor not being stopped before it's deleted.