### PR TITLE
Switch to using default GitHub token in Actions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,16 +30,16 @@ jobs:
         run: python --version && pip --version
 
       - name: Get yagna deb file
-        run:  pip install requests && python ./docker/download_artifacts.py -t ${{ secrets.YAGNA_WORKFLOW_TOKEN }}
+        run:  pip install requests && python ./docker/download_artifacts.py -t ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get version of yagna deb file
         run: echo ::set-env name=YAGNA_DEB::$(dpkg-deb -f ./yagna.deb Version)
 
-      - run: echo ${{ secrets.YAGNA_WORKFLOW_TOKEN }} | docker login docker.pkg.github.com -u ${{github.actor}} --password-stdin
+      - run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u ${{github.actor}} --password-stdin
 
       - name: Build the docker-compose stack
         env:
-          GITHUB_API_TOKEN: ${{ secrets.YAGNA_WORKFLOW_TOKEN }}
+          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           YAGNA_DEB: ${{ env.YAGNA_DEB }}
         run: |
           docker-compose -f docker/docker-compose.yml pull --ignore-pull-failures
@@ -98,16 +98,16 @@ jobs:
         run: python --version && pip --version
 
       - name: Get yagna deb file
-        run:  pip install requests && python ./docker/download_artifacts.py -t ${{ secrets.YAGNA_WORKFLOW_TOKEN }}
+        run:  pip install requests && python ./docker/download_artifacts.py -t ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get version of yagna deb file
         run: echo ::set-env name=YAGNA_DEB::$(dpkg-deb -f ./yagna.deb Version)
 
-      - run: echo ${{ secrets.YAGNA_WORKFLOW_TOKEN }} | docker login docker.pkg.github.com -u ${{github.actor}} --password-stdin
+      - run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u ${{github.actor}} --password-stdin
 
       - name: Build the docker-compose stack
         env:
-          GITHUB_API_TOKEN: ${{ secrets.YAGNA_WORKFLOW_TOKEN }}
+          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           YAGNA_DEB: ${{ env.YAGNA_DEB }}
         run: |
           docker-compose -f docker/docker-compose.yml pull --ignore-pull-failures


### PR DESCRIPTION
Part of: #118 

With the `yagna` repository now being public, it's enough to use the default token that GitHub provides for each job run on Actions (more details on this token [here](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token)). Once this is merged the token stored under `YAGNA_WORKFLOW_TOKEN` in secrets can be removed and invalidated (however I do not have the permissions to do this, perhaps @maaktweluit or @stranger80 can help me out here?).