### PR TITLE
Revert using default GitHub token in actions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - km/revert-github-token
+      # - <your-branch>    # put your branch name here to test it @ GH Actions
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Reverts: #235 

This is necessary as #220 requires access to a Docker image from the repo [gnt2](https://github.com/golemfactory/gnt2) which is currently private.
I enabled running the integration test workflow on this branch to see whether the Docker login step passes correctly. I will remove this change before merging.