### PR TITLE
Change default yagna artifact name

### DIFF
--- a/docker/download_artifacts.py
+++ b/docker/download_artifacts.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 ENV_API_TOKEN = "GITHUB_API_TOKEN"
 ENV_YAGNA_COMMIT = "YAGNA_COMMIT_HASH"
 
-ARTIFACT_NAMES = ["yagna", "ya-sb-router"]
+ARTIFACT_NAMES = ["golem-requestor", "ya-sb-router"]
 BRANCH = "master"
 REPO_OWNER = "golemfactory"
 REPO_NAME = "yagna"


### PR DESCRIPTION
Required for: https://github.com/golemfactory/yagna/pull/706

Since https://github.com/golemfactory/yagna/commit/07a7305c505dfab4994c63c31868bc3b25a8cd58, the yagna `.deb` packages have been renamed to `golem-requestor` and `golem-provider`. This requires an update of the default artifact name the downloader script uses.