### PR TITLE
Update zksync-mock image to donate more

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,7 +28,7 @@ services:
             - "8545:8545"
 
     zksync:
-        image: docker.pkg.github.com/golemfactory/yagna-zksync/yagna-zksync-mock:a352987631ba
+        image: docker.pkg.github.com/golemfactory/yagna-zksync/yagna-zksync-mock:671d3f74a3aa
         ports:
             - "3030:3030"
         environment:


### PR DESCRIPTION
Now allocations require 100 GNT per task, so made the donation 1000.