### PR TITLE
Update zksync mock version to 0.1.1

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,7 +28,7 @@ services:
             - "8545:8545"
 
     zksync:
-        image: docker.pkg.github.com/golemfactory/yagna-zksync/yagna-zksync-mock:671d3f74a3aa
+        image: docker.pkg.github.com/golemfactory/yagna-zksync/yagna-zksync-mock:fe8f9ca005a3
         ports:
             - "3030:3030"
         environment:


### PR DESCRIPTION
Updated the `zksync_mock_server` to represent version 0.1.1 of zksync.

Added an extra commit to test the PR in yagna: https://github.com/golemfactory/yagna/pull/815
Will remove this commit ( and need new approval ) before merging