### PR TITLE
Skip VM tests on GitHub-hosted runners

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,6 +38,7 @@ jobs:
 
       - name: Run test suite
         env:
+          ENABLE_VM_TESTS: 'true'
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # ugly hack to make assets work, fix progress tracked here: https://github.com/golemfactory/yagna-integration/issues/336
         run: python -m pytest test/yagna --assets-path=/opt/actions-runner/_work/yagna-integration/yagna-integration/test/yagna/e2e/assets -svx

--- a/test/yagna/e2e/test_e2e_vm.py
+++ b/test/yagna/e2e/test_e2e_vm.py
@@ -103,6 +103,10 @@ def _exe_script(runner: Runner, output_file: str):
     ]
 
 
+@pytest.mark.skipif(
+    (os.getenv("GITHUB_ACTIONS") == "true") and (os.getenv("ENABLE_VM_TESTS") is None),
+    reason="Running in GitHub Actions (no nested virtualization)",
+)
 @pytest.mark.asyncio
 async def test_e2e_vm_success(
     assets_path: Path,


### PR DESCRIPTION
Fixes a problem introduced in https://github.com/golemfactory/yagna-integration/pull/339 where VM tests would attempt to run even when we're not using a self-hosted runner (e.g. in `yagna` repo).