### PR TITLE
Install goth package in unit_test job

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -28,7 +28,7 @@ jobs:
           poetry-version: 1.1.4
           
       - name: Install dependencies
-        run: poetry install --no-root
+        run: poetry install
 
       - name: Run unit tests
         run: poetry run poe unit_test

--- a/test/yagna/e2e/test_e2e_vm.py
+++ b/test/yagna/e2e/test_e2e_vm.py
@@ -107,7 +107,8 @@ def _exe_script(runner: Runner, output_file: str):
 @pytest.mark.skipif(
     sys.platform != "linux"
     or (os.getenv("GITHUB_ACTIONS") == "true" and os.getenv("ENABLE_VM_TESTS") is None),
-    reason="VM test is only supported on bare-metal Linux (e.g. only self-hosted github actions runners)",
+    reason="VM test is only supported on bare-metal Linux \
+            (e.g. only self-hosted github actions runners)",
 )
 @pytest.mark.asyncio
 async def test_e2e_vm_success(


### PR DESCRIPTION
Resolves unit tests failing in CI (e.g. https://github.com/golemfactory/goth/pull/371/checks?check_run_id=1563609223).