### PR TITLE
Change default web server port

### DIFF
--- a/goth/address.py
+++ b/goth/address.py
@@ -105,3 +105,8 @@ HOST_REST_PORT_END = 6100
 # Port used by the mitmproxy instance
 # NOTE: This variable is used in `nginx.conf` file in the proxy container:
 MITM_PROXY_PORT = 9000
+
+# Port range used by the internal web server spawned by goth for each test
+# Ports are rotated and re-used in a circular fashion
+WEB_SERVER_PORT_START = 9201
+WEB_SERVER_PORT_END = 9251

--- a/goth/runner/__init__.py
+++ b/goth/runner/__init__.py
@@ -29,7 +29,7 @@ import goth.runner.container.payment as payment
 from goth.runner.log import LogConfig
 from goth.runner.probe import Probe
 from goth.runner.proxy import Proxy
-from goth.runner.web_server import WebServer
+from goth.runner.web_server import WebServer, DEFAULT_SERVER_PORT
 
 
 logger = logging.getLogger(__name__)
@@ -96,9 +96,6 @@ def step(default_timeout: float = 10.0):
     return decorator
 
 
-DEFAULT_WEB_SERVER_PORT = 8080
-
-
 class Runner:
     """Manages the nodes and runs the scenario on them."""
 
@@ -143,7 +140,7 @@ class Runner:
         compose_config: ComposeConfig,
         test_failure_callback: Callable[[TestFailure], None],
         cancellation_callback: Callable[[], None],
-        web_server_port: int = DEFAULT_WEB_SERVER_PORT,
+        web_server_port: int = DEFAULT_SERVER_PORT,
     ):
         self.api_assertions_module = api_assertions_module
         self.assets_path = assets_path

--- a/goth/runner/__init__.py
+++ b/goth/runner/__init__.py
@@ -29,7 +29,7 @@ import goth.runner.container.payment as payment
 from goth.runner.log import LogConfig
 from goth.runner.probe import Probe
 from goth.runner.proxy import Proxy
-from goth.runner.web_server import WebServer, DEFAULT_SERVER_PORT
+from goth.runner.web_server import WebServer
 
 
 logger = logging.getLogger(__name__)
@@ -140,7 +140,7 @@ class Runner:
         compose_config: ComposeConfig,
         test_failure_callback: Callable[[TestFailure], None],
         cancellation_callback: Callable[[], None],
-        web_server_port: int = DEFAULT_SERVER_PORT,
+        web_server_port: Optional[int] = None,
     ):
         self.api_assertions_module = api_assertions_module
         self.assets_path = assets_path

--- a/goth/runner/web_server.py
+++ b/goth/runner/web_server.py
@@ -11,6 +11,8 @@ from aiohttp import web, web_runner
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_SERVER_PORT = 9292
+
 
 class WebServer:
     """A simple web server implemented with the `aiohttp` library."""


### PR DESCRIPTION
Since #349 the internal web server used by `goth` listens on all interfaces of the host. To avoid potential collisions (and leftovers from previous tests) the web server now uses ports from a rotating, fixed range. A new port number is used for each test in a single run of `goth`.