### PR TITLE
Add network & token fields to Account class; reame "ngnt" to "erc20"

### DIFF
--- a/test/goth/runner/container/test_payment.py
+++ b/test/goth/runner/container/test_payment.py
@@ -17,7 +17,7 @@ def payment_id_pool() -> PaymentIdPool:
 
 def test_get_id(payment_id_pool):
     """Test if pre-funded payment accounts are generated correctly."""
-    drivers = [PaymentDriver.ngnt, PaymentDriver.zksync]
+    drivers = [PaymentDriver.erc20, PaymentDriver.zksync]
     receive = False
     send = False
 


### PR DESCRIPTION
Adjusting `goth.runner.container.payment` to changes introduced in https://github.com/golemfactory/yagna/pull/912

* Fields `network` and `token` are added to the dataclass `goth.runner.container.payment.Account`
* The driver name `ngnt` has been replaced with `erc20`
* `PaymentIdPool` now accepts an optional `key_dir` for using a key directory different than `test/yagna/keys` -- this change is not related to https://github.com/golemfactory/yagna/pull/912 but will make `PaymentIdPool` a bit more flexible and may be useful for `goth` usage scenarios when `test` subdirectory is not there.