### PR TITLE
Add support for using yagna releases

### DIFF
--- a/docker/yagna-goth-deb.Dockerfile
+++ b/docker/yagna-goth-deb.Dockerfile
@@ -1,0 +1,7 @@
+FROM debian:bullseye-slim
+COPY deb/* ./
+RUN chmod +x /usr/bin/* \
+    && apt update \
+    && yes | apt install -y ./*.deb \
+    && apt install -y libssl-dev
+ENTRYPOINT /usr/bin/yagna

--- a/goth/runner/container/build.py
+++ b/goth/runner/container/build.py
@@ -20,6 +20,7 @@ from goth.runner.process import run_command
 logger = logging.getLogger(__name__)
 
 DOCKERFILE_PATH = DOCKER_DIR / f"{YagnaContainer.IMAGE}.Dockerfile"
+DOCKERFILE_DEB_PATH = DOCKER_DIR / f"{YagnaContainer.IMAGE}-deb.Dockerfile"
 
 EXPECTED_BINARIES = {
     "exe-unit",
@@ -49,6 +50,8 @@ class YagnaBuildEnvironment:
     """git commit hash in yagna repo for which to download binaries."""
     deb_path: Optional[Path]
     """Local path to .deb file or dir with .deb files to be installed in the image."""
+    release_tag: Optional[str]
+    """Release tag substring used to filter the GitHub release to download."""
 
 
 async def _build_docker_image(
@@ -92,10 +95,12 @@ async def build_proxy_image() -> None:
 async def build_yagna_image(environment: YagnaBuildEnvironment) -> None:
     """Build the yagna Docker image."""
 
+    dockerfile = DOCKERFILE_DEB_PATH if environment.release_tag else DOCKERFILE_PATH
+
     await _build_docker_image(
         YagnaContainer.IMAGE,
-        DOCKERFILE_PATH,
-        lambda build_dir: _setup_build_context(build_dir, environment),
+        dockerfile,
+        lambda build_dir: _setup_build_context(build_dir, environment, dockerfile),
     )
 
 
@@ -111,11 +116,13 @@ def _download_artifact(env: YagnaBuildEnvironment, download_path: Path) -> None:
     downloader.download(artifact_name="Yagna Linux", output=download_path, **kwargs)
 
 
-def _download_release(download_path: Path, repo: str, tag_substring: str = "") -> None:
-    downloader = ReleaseDownloader(
-        repo=repo, tag_substring=tag_substring, token=os.environ.get(ENV_API_TOKEN)
+def _download_release(
+    download_path: Path, repo: str, tag_substring: str = "", asset_name: str = ""
+) -> None:
+    downloader = ReleaseDownloader(repo=repo, token=os.environ.get(ENV_API_TOKEN))
+    downloader.download(
+        output=download_path, asset_name=asset_name, tag_substring=tag_substring
     )
-    downloader.download(output=download_path)
 
 
 def _find_expected_binaries(root_path: Path) -> List[Path]:
@@ -137,11 +144,13 @@ def _find_expected_binaries(root_path: Path) -> List[Path]:
     return binary_paths
 
 
-def _setup_build_context(context_dir: Path, env: YagnaBuildEnvironment) -> None:
+def _setup_build_context(
+    context_dir: Path, env: YagnaBuildEnvironment, dockerfile: Path
+) -> None:
     """Set up the build context for `docker build` command.
 
     This function prepares a directory to be used as build context for
-    yagna-goth.Dockerfile. This includes copying the original Dockerfile and creating
+    building yagna image. This includes copying the original Dockerfile and creating
     two directories: `bin` and `deb`. Depending on the build environment, these will be
     populated with assets from either the local filesystem or downloaded from GitHub.
     """
@@ -156,7 +165,11 @@ def _setup_build_context(context_dir: Path, env: YagnaBuildEnvironment) -> None:
     context_binary_dir.mkdir()
     context_deb_dir.mkdir()
 
-    if env.binary_path:
+    if env.release_tag:
+        logger.info("Using yagna release. tag_substring=%s", env.release_tag)
+        release_tag = "" if env.release_tag == "latest" else env.release_tag
+        _download_release(context_deb_dir, "yagna", release_tag, "provider")
+    elif env.binary_path:
         if env.binary_path.is_dir():
             logger.info("Using local yagna binaries. path=%s", env.binary_path)
             binary_paths = _find_expected_binaries(env.binary_path)
@@ -181,6 +194,6 @@ def _setup_build_context(context_dir: Path, env: YagnaBuildEnvironment) -> None:
             _download_release(context_deb_dir, repo)
 
     logger.debug(
-        "Copying Dockerfile. source=%s, destination=%s", DOCKERFILE_PATH, context_dir
+        "Copying Dockerfile. source=%s, destination=%s", dockerfile, context_dir
     )
-    shutil.copy2(DOCKERFILE_PATH, context_dir / "Dockerfile")
+    shutil.copy2(dockerfile, context_dir / "Dockerfile")

--- a/scripts/download_release.py
+++ b/scripts/download_release.py
@@ -13,6 +13,12 @@ from goth.runner.download import (
 parser = argparse.ArgumentParser()
 parser.add_argument("-c", "--content-type", default=DEFAULT_CONTENT_TYPE)
 parser.add_argument(
+    "-n",
+    "--name",
+    help="Substring the asset to download should contain.",
+    type=str,
+)
+parser.add_argument(
     "-o",
     "--output",
     help="Output path, may be either a file or a directory.",
@@ -33,7 +39,5 @@ parser.add_argument("repo", help="Name of the git repository to be used.")
 
 if __name__ == "__main__":
     args = parser.parse_args()
-    downloader = ReleaseDownloader(
-        args.repo, token=args.token, verbose=args.verbose, tag_substring=args.tag
-    )
-    downloader.download(args.content_type, args.output)
+    downloader = ReleaseDownloader(args.repo, token=args.token, verbose=args.verbose)
+    downloader.download(args.name, args.content_type, args.output, args.tag)

--- a/test/yagna/conftest.py
+++ b/test/yagna/conftest.py
@@ -22,6 +22,12 @@ def pytest_addoption(parser):
         help="path to custom assets to be used by yagna containers",
     )
     parser.addoption(
+        "--deb-package",
+        action="store",
+        help="path to local .deb file or dir with .deb packages to be installed in \
+                yagna containers",
+    )
+    parser.addoption(
         "--logs-path",
         action="store",
         help="path under which all test run logs should be stored",
@@ -42,17 +48,20 @@ def pytest_addoption(parser):
         help="git commit hash in yagna repo for which to download binaries",
     )
     parser.addoption(
-        "--yagna-deb-path",
-        action="store",
-        help="path to local .deb file or dir with .deb packages to be installed in \
-                yagna containers",
-    )
-    parser.addoption(
         "--yagna-release",
         action="store",
         help="release tag substring specifying which yagna release should be used. \
                 If this is equal to 'latest', latest yagna release will be used.",
     )
+
+
+@pytest.fixture(scope="session")
+def deb_package(request) -> Optional[Path]:
+    """Fixture that passes the --deb-package CLI parameter to the test suite."""
+    deb_path = request.config.option.deb_package
+    if deb_path:
+        return Path(deb_path)
+    return None
 
 
 @pytest.fixture(scope="session")
@@ -99,15 +108,6 @@ def yagna_commit_hash(request) -> Optional[str]:
 
 
 @pytest.fixture(scope="session")
-def yagna_deb_path(request) -> Optional[Path]:
-    """Fixture that passes the --yagna-deb-dir CLI parameter to the test suite."""
-    deb_path = request.config.option.yagna_deb_path
-    if deb_path:
-        return Path(deb_path)
-    return None
-
-
-@pytest.fixture(scope="session")
 def yagna_release(request) -> Optional[str]:
     """Fixture that passes the --yagna-release CLI parameter to the test suite."""
     return request.config.option.yagna_release
@@ -118,7 +118,7 @@ def yagna_build_env(
     yagna_binary_path: Optional[Path],
     yagna_branch: Optional[str],
     yagna_commit_hash: Optional[str],
-    yagna_deb_path: Optional[Path],
+    deb_package: Optional[Path],
     yagna_release: Optional[str],
 ) -> YagnaBuildEnvironment:
     """Fixture which provides the build environment for yagna Docker images."""
@@ -126,7 +126,7 @@ def yagna_build_env(
         binary_path=yagna_binary_path,
         branch=yagna_branch,
         commit_hash=yagna_commit_hash,
-        deb_path=yagna_deb_path,
+        deb_path=deb_package,
         release_tag=yagna_release,
     )
 

--- a/test/yagna/conftest.py
+++ b/test/yagna/conftest.py
@@ -47,6 +47,12 @@ def pytest_addoption(parser):
         help="path to local .deb file or dir with .deb packages to be installed in \
                 yagna containers",
     )
+    parser.addoption(
+        "--yagna-release",
+        action="store",
+        help="release tag substring specifying which yagna release should be used. \
+                If this is equal to 'latest', latest yagna release will be used.",
+    )
 
 
 @pytest.fixture(scope="session")
@@ -102,11 +108,18 @@ def yagna_deb_path(request) -> Optional[Path]:
 
 
 @pytest.fixture(scope="session")
+def yagna_release(request) -> Optional[str]:
+    """Fixture that passes the --yagna-release CLI parameter to the test suite."""
+    return request.config.option.yagna_release
+
+
+@pytest.fixture(scope="session")
 def yagna_build_env(
     yagna_binary_path: Optional[Path],
     yagna_branch: Optional[str],
     yagna_commit_hash: Optional[str],
     yagna_deb_path: Optional[Path],
+    yagna_release: Optional[str],
 ) -> YagnaBuildEnvironment:
     """Fixture which provides the build environment for yagna Docker images."""
     return YagnaBuildEnvironment(
@@ -114,6 +127,7 @@ def yagna_build_env(
         branch=yagna_branch,
         commit_hash=yagna_commit_hash,
         deb_path=yagna_deb_path,
+        release_tag=yagna_release,
     )
 
 


### PR DESCRIPTION
Resolves: #394 

Adds support for installing `yagna` from a GitHub release when running the `goth` test network. This is enabled using `--yagna-release` argument on the pytest/poe call. This argument is a substring to look for in the name of the release's tag. If `latest` is given as its value, the latest yagna release will be used.