### PR TITLE
Creating and removing containers in Probes using ContextManager protocol

### DIFF
--- a/goth/runner/container/compose.py
+++ b/goth/runner/container/compose.py
@@ -83,16 +83,6 @@ class ComposeNetworkManager:
         self._log_monitors = {}
         self._network_gateway_address = ""
 
-    @contextlib.asynccontextmanager
-    async def run(self, log_dir: Path, force_build: bool = False) -> None:
-        """Implement AsyncContextManager protocol for compose network manager."""
-
-        try:
-            await self.start_network(log_dir, force_build)
-            yield
-        finally:
-            await self.stop_network()
-
     async def start_network(self, log_dir: Path, force_build: bool = False) -> None:
         """Start the compose network based on this manager's compose file.
 
@@ -201,3 +191,16 @@ class ComposeNetworkManager:
                 )
             )
             self._log_monitors[service_name] = monitor
+
+
+@contextlib.asynccontextmanager
+async def run_compose_network(
+    compose_manager: ComposeNetworkManager, log_dir: Path, force_build: bool = False
+) -> None:
+    """Implement AsyncContextManager for starting/stopping docker compose network."""
+
+    try:
+        await compose_manager.start_network(log_dir, force_build)
+        yield
+    finally:
+        await compose_manager.stop_network()

--- a/goth/runner/exceptions.py
+++ b/goth/runner/exceptions.py
@@ -23,5 +23,23 @@ class StopThreadException(Exception):
     """Exception used to stop a running `StoppableThread`."""
 
 
+class TestFailure(Exception):
+    """Base class for errors raised by the test runner when a test fails."""
+
+
+class StepTimeoutError(TestFailure):
+    """Raised on test step timeout."""
+
+    def __init__(self, step: str, time: float):
+        super().__init__(f"Step '{step}' timed out after {time:.1f} s")
+
+
+class TemporalAssertionError(TestFailure):
+    """Raised on temporal assertion failure."""
+
+    def __init__(self, assertion: str):
+        super().__init__(f"Temporal assertion '{assertion}' failed")
+
+
 class TimeoutError(Exception):
     """Exception for when a timeout occurs."""

--- a/goth/runner/probe.py
+++ b/goth/runner/probe.py
@@ -129,7 +129,12 @@ class Probe(abc.ABC):
         self._logger.info("Stopping probe")
         if self.container.logs:
             await self.container.logs.stop()
-        self.container.remove(force=True)
+
+    def remove(self) -> None:
+        """Remove the underlying container."""
+        if self.container:
+            self.container.remove(force=True)
+            self._logger.debug("Container removed")
 
     async def _start_container(self) -> None:
         """

--- a/goth/runner/probe.py
+++ b/goth/runner/probe.py
@@ -101,17 +101,6 @@ class Probe(abc.ABC):
         """Name of the container."""
         return self.container.name
 
-    @contextlib.asynccontextmanager
-    async def run(self) -> str:
-        """Implement AsyncContextManager protocol for a probe."""
-
-        try:
-            await self.start()
-            assert self.ip_address
-            yield self.ip_address
-        finally:
-            await self.stop()
-
     async def start(self) -> None:
         """Start the probe.
 
@@ -201,6 +190,38 @@ class Probe(abc.ABC):
             )
             key = app_key.key
         return key
+
+
+@contextlib.contextmanager
+def create_probe(
+    runner: "Runner",
+    docker_client: DockerClient,
+    config: YagnaContainerConfig,
+    log_config: LogConfig,
+) -> Probe:
+    """Implement a ContextManager protocol for creating and removing probes."""
+
+    probe: Optional[Probe] = None
+    try:
+        probe = config.probe_type(runner, docker_client, config, log_config)
+        for name, value in config.probe_properties.items():
+            probe.__setattr__(name, value)
+        yield probe
+    finally:
+        if probe:
+            probe.remove()
+
+
+@contextlib.asynccontextmanager
+async def run_probe(probe: Probe) -> str:
+    """Implement AsyncContextManager for starting and stopping a probe."""
+
+    try:
+        await probe.start()
+        assert probe.ip_address
+        yield probe.ip_address
+    finally:
+        await probe.stop()
 
 
 class RequestorProbe(ApiClientMixin, Probe):

--- a/goth/runner/proxy.py
+++ b/goth/runner/proxy.py
@@ -59,16 +59,6 @@ class Proxy:
         if assertions_module:
             self.monitor.load_assertions(assertions_module)
 
-    @contextlib.contextmanager
-    def run(self):
-        """Implement AsyncContextManager protocol for Proxy."""
-
-        try:
-            self.start()
-            yield
-        finally:
-            self.stop()
-
     def start(self):
         """Start the proxy thread."""
         self._proxy_thread.start()
@@ -111,3 +101,14 @@ class Proxy:
         args = f"-q --mode reverse:http://127.0.0.1 --listen-port {MITM_PROXY_PORT}"
         _main.run(MITMProxyRunner, cmdline.mitmdump, args.split())
         self._logger.info("Embedded mitmproxy exited")
+
+
+@contextlib.contextmanager
+def run_proxy(proxy: Proxy) -> Proxy:
+    """Implement ContextManager protocol for stating and stopping a Proxy."""
+
+    try:
+        proxy.start()
+        yield
+    finally:
+        proxy.stop()

--- a/goth/runner/step.py
+++ b/goth/runner/step.py
@@ -5,6 +5,7 @@ import logging
 import time
 from typing import Optional
 
+from goth.runner.exceptions import StepTimeoutError
 from goth.runner.probe import Probe
 
 
@@ -27,15 +28,19 @@ def step(default_timeout: float = 10.0):
                 self.runner.check_assertion_errors()
                 step_time = time.time() - start_time
                 logger.debug(
-                    "Finished step '%s', result: %s, time: %s",
+                    "Finished step '%s', result: %s, time: %.1f s",
                     step_name,
                     result,
                     step_time,
                 )
+            except asyncio.TimeoutError:
+                step_time = time.time() - start_time
+                logger.error("Step '%s' timed out after %.1f s", step_name, step_time)
+                raise StepTimeoutError(step_name, step_time)
             except Exception as exc:
                 step_time = time.time() - start_time
                 logger.error(
-                    "Step '%s' raised %s in %s",
+                    "Step '%s' raised %s in %.1f",
                     step_name,
                     exc.__class__.__name__,
                     step_time,

--- a/goth/runner/web_server.py
+++ b/goth/runner/web_server.py
@@ -47,16 +47,6 @@ class WebServer:
                 out.write(data)
         return web.Response()
 
-    @contextlib.asynccontextmanager
-    async def run(self, server_address: Optional[str]) -> None:
-        """Implement AsyncContextManager protocol for a web server."""
-
-        try:
-            await self.start(server_address)
-            yield
-        finally:
-            await self.stop()
-
     async def start(self, server_address: Optional[str]) -> None:
         """Start serving content."""
 
@@ -93,3 +83,14 @@ class WebServer:
         await self._server_task
         self._server_task = None
         logger.info("Stopped the web server")
+
+
+@contextlib.asynccontextmanager
+async def run_web_server(server: WebServer, server_address: Optional[str]) -> None:
+    """Implement AsyncContextManager protocol for starting/stopping a web server."""
+
+    try:
+        await server.start(server_address)
+        yield
+    finally:
+        await server.stop()

--- a/test/yagna/interactive/conftest.py
+++ b/test/yagna/interactive/conftest.py
@@ -52,12 +52,3 @@ def test_failure_callback() -> Callable[[TestFailure], None]:
     return lambda error: logger.error(
         f"The runner was stopped due to test failure: {error}"
     )
-
-
-@pytest.hookimpl
-def pytest_report_teststatus(report, config):
-    """Suppress printing test status for interactive testing session."""
-
-    # Return section, one-letter and verbose status, e.g. ("failed", "F", "FAILED").
-    # Returning empty strings will suppress printing status.
-    return "", "", ""  # e.g. "failed", "F", "FAILED"


### PR DESCRIPTION
Resolves #405 
Resolves #398 

Most important change is adding a function `_create_probe()` in `goth/runner/__init__.py` that implements the `ContextManager` protocol and is used for ensuring that `docker` containers created in `Probe.__init__()` are removed before the runner that owns the probes exits.

Additionally, implementations of (`Async`)`ContextManager` protocol used to start and stop `goth` components in `Runner.__call__()` are removed from classes such as `Probe` or `Proxy` to top-level functions to make the class interfaces more clean.