### PR TITLE
Remove pytest.skip from VM runtime test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -37,7 +37,6 @@ jobs:
 
       - name: Run test suite
         env:
-          ENABLE_VM_TESTS: 'true'
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: poetry run poe ci_test_self_hosted --yagna-release latest
 

--- a/test/yagna/e2e/test_e2e_vm.py
+++ b/test/yagna/e2e/test_e2e_vm.py
@@ -3,7 +3,6 @@
 import json
 import logging
 import os
-import sys
 from pathlib import Path
 from typing import List
 
@@ -104,12 +103,6 @@ def _exe_script(runner: Runner, output_file: str):
     ]
 
 
-@pytest.mark.skipif(
-    sys.platform != "linux"
-    or (os.getenv("GITHUB_ACTIONS") == "true" and os.getenv("ENABLE_VM_TESTS") is None),
-    reason="VM test is only supported on bare-metal Linux \
-            (e.g. only self-hosted github actions runners)",
-)
 @pytest.mark.asyncio
 async def test_e2e_vm_success(
     assets_path: Path,


### PR DESCRIPTION
Since https://github.com/golemfactory/goth/pull/416 we've switched to self-hosted runners which support `kvm` virtualization.