### PR TITLE
Less verbose and more informative logs from event monitors

### DIFF
--- a/goth/runner/agent.py
+++ b/goth/runner/agent.py
@@ -42,11 +42,12 @@ class AgentMixin(abc.ABC):
             await self.agent_logs.stop()
 
     def _init_log_monitor(self):
-        log_config = LogConfig(file_name=f"{self.name}_agent")
+        name = f"{self.name}_agent"
+        log_config = LogConfig(file_name=name)
         if self.container.log_config:
             log_config.base_dir = self.container.log_config.base_dir
 
-        self.agent_logs = LogEventMonitor(log_config)
+        self.agent_logs = LogEventMonitor(name, log_config)
         self._last_checked_line = -1
 
     async def _wait_for_agent_log(

--- a/goth/runner/container/__init__.py
+++ b/goth/runner/container/__init__.py
@@ -121,7 +121,7 @@ class DockerContainer:
         self.log_config = log_config
         self.logs = None
         if self.log_config:
-            self.logs = LogEventMonitor(self.log_config)
+            self.logs = LogEventMonitor(self.name, self.log_config)
 
         self._container = self._client.containers.create(
             self.image,

--- a/goth/runner/container/compose.py
+++ b/goth/runner/container/compose.py
@@ -175,7 +175,7 @@ class ComposeNetworkManager:
         for service_name in self._get_compose_services():
             log_config = LogConfig(service_name)
             log_config.base_dir = log_dir
-            monitor = LogEventMonitor(log_config)
+            monitor = LogEventMonitor(service_name, log_config)
 
             containers = self._docker_client.containers.list(
                 filters={"name": service_name}

--- a/goth/runner/log_monitor.py
+++ b/goth/runner/log_monitor.py
@@ -134,8 +134,8 @@ class LogEventMonitor(EventMonitor[LogEvent]):
     were logged after this line.
     """
 
-    def __init__(self, log_config: LogConfig):
-        super().__init__()
+    def __init__(self, name: str, log_config: LogConfig):
+        super().__init__(name)
         self._file_logger = _create_file_logger(log_config)
         self._buffer_task = None
         self._last_checked_line = -1

--- a/goth/runner/proxy.py
+++ b/goth/runner/proxy.py
@@ -55,7 +55,7 @@ class Proxy:
             if self._loop and self._loop.is_running():
                 self._loop.stop()
 
-        self.monitor = EventMonitor(self._logger, on_stop=_stop_callback)
+        self.monitor = EventMonitor("rest", self._logger, on_stop=_stop_callback)
         if assertions_module:
             self.monitor.load_assertions(assertions_module)
 


### PR DESCRIPTION
Resolves #430 

Changes in this PR:

* Event monitors now have optional names which are used to distinguish log messages for distinct event monitors:
  ```2021-03-03 17:30:08+0000 INFO     goth.runner.probe              [provider_1] Stopping probe
  2021-03-03 17:30:08+0000 DEBUG    goth.assertions.monitor        [provider_1] Stopping the monitor...
  2021-03-03 17:30:08+0000 DEBUG    goth.assertions.monitor        [provider_1] Monitor stopped
  2021-03-03 17:30:08+0000 DEBUG    goth.assertions.monitor        [provider_1_agent] Stopping the monitor...
  2021-03-03 17:30:08+0000 DEBUG    goth.assertions.monitor        [provider_1_agent] Monitor stopped
  2021-03-03 17:30:08+0000 INFO     goth.runner.probe              [requestor] Stopping probe
  2021-03-03 17:30:08+0000 DEBUG    goth.assertions.monitor        [requestor] Stopping the monitor...
  2021-03-03 17:30:08+0000 DEBUG    goth.assertions.monitor        [requestor] Monitor stopped
  ```
* Assertions are now added to a monitor with specific log levels; when an assertion succeeds, the monitor logs the success message with the log level specified when adding the assertion. This allows us to reduce noise in `INFO`-level logs by adding some assertions with level `DEBUG`:
  ```
  2021-03-03 17:30:01+0100 INFO     goth.runner.step               Running step 'provider_1.wait_for_invoice_paid(timeout=300)'
  2021-03-03 17:30:01+0100 DEBUG    goth.assertions.monitor        [provider_1_agent] Assertion 'goth.runner.log_monitor.wait_for_matching_line' started
  2021-03-03 17:30:08+0100 DEBUG    goth.assertions.monitor        [provider_1_agent] Assertion 'goth.runner.log_monitor.wait_for_matching_line' succeeded after event: #639 (<LogEvent time=1614807008, level=LogLevel.INFO, module= ya_provider::payments::payments, message=Invoice [63c2b1b8-f97c-49df-b27b-954acfcb9c6f] for agreement [134f97f98c35c0a2737c13108f70dea42f7720fdbeede46b60daef0f60000a87] was paid. Amount: 0.004982769803055556.,  >); result: <LogEvent time=1614807008, level=LogLevel.INFO, module= ya_provider::payments::payments, message=Invoice [63c2b1b8-f97c-49df-b27b-954acfcb9c6f] for agreement [134f97f98c35c0a2737c13108f70dea42f7720fdbeede46b60daef0f60000a87] was paid. Amount: 0.004982769803055556.,  >
  ...
  2021-03-03 17:30:08+0100 INFO     goth.runner.proxy              [rest] Assertion 'test.yagna.assertions.e2e_wasm_assertions.assert_no_errors_until_invoice_sent' succeeded after event: EndOfEvents; result: None
  ```