### PR TITLE
Add missing wait_for_approval call to negotiate_agreements

### DIFF
--- a/goth/runner/requestor.py
+++ b/goth/runner/requestor.py
@@ -177,6 +177,11 @@ class MarketOperationsMixin:
         await self.market.confirm_agreement(agreement_id)
 
     @step()
+    async def wait_for_approval(self: RequestorProbe, agreement_id: str) -> None:
+        """Call wait_for_approval on the requestor market api."""
+        await self.market.wait_for_approval(agreement_id)
+
+    @step()
     async def terminate_agreement(
         self: RequestorProbe, agreement_id: str, reason: Optional[str]
     ):

--- a/test/yagna/e2e/test_e2e_vm.py
+++ b/test/yagna/e2e/test_e2e_vm.py
@@ -167,6 +167,7 @@ async def test_e2e_vm_success(
             agreement_id = await requestor.create_agreement(new_proposal)
             await requestor.confirm_agreement(agreement_id)
             await provider.wait_for_agreement_approved()
+            await requestor.wait_for_approval(agreement_id)
             agreement_providers.append((agreement_id, provider))
 
         await requestor.unsubscribe_demand(subscription_id)

--- a/test/yagna/e2e/test_e2e_wasm.py
+++ b/test/yagna/e2e/test_e2e_wasm.py
@@ -124,6 +124,7 @@ async def test_e2e_wasm_success(
             agreement_id = await requestor.create_agreement(new_proposal)
             await requestor.confirm_agreement(agreement_id)
             await provider.wait_for_agreement_approved()
+            await requestor.wait_for_approval(agreement_id)
             agreement_providers.append((agreement_id, provider))
 
         await requestor.unsubscribe_demand(subscription_id)

--- a/test/yagna/helpers/negotiation.py
+++ b/test/yagna/helpers/negotiation.py
@@ -106,6 +106,7 @@ async def negotiate_agreements(
         agreement_id = await requestor.create_agreement(new_proposal)
         await requestor.confirm_agreement(agreement_id)
         await provider.wait_for_agreement_approved()
+        await requestor.wait_for_approval(agreement_id)
         agreement_providers.append((agreement_id, provider))
 
     await requestor.unsubscribe_demand(subscription_id)


### PR DESCRIPTION
During agreement negotiation, the requestor should call `wait_for_approval`, which blocks until the provider accepts the agreement, before trying to create an activity for this agreement. Without this step, activity creation may fail, as seen in this snippet from the provider daemon log in https://github.com/golemfactory/goth/pull/431/checks?check_run_id=2024210751 (notice the `WARN` message):
```
[2021-03-03T17:31:20Z DEBUG ya_market::protocol::negotiation::provider] Negotiation API: Agreement proposal [R-5e6edb09a5fbbff3c3d07b0942ca78eeb0131bf074d93ae99d97e22c2ace0e3d] sent by [0x63fc2ad3d021a4d7e64323529a55a9442c444da0].
[2021-03-03T17:31:20Z INFO  ya_market::negotiation::provider] Agreement proposal [P-5e6edb09a5fbbff3c3d07b0942ca78eeb0131bf074d93ae99d97e22c2ace0e3d] received from [0x63fc2ad3d021a4d7e64323529a55a9442c444da0].
[2021-03-03T17:31:20Z INFO  actix_web::middleware::logger] 127.0.0.1:38932 "GET /market-api/v1/offers/1a5a427566664df79147209b179121ba-a0d58c2e2c02bd370fec4739a891d8f9e696982742be67a74fdbd2c4af9485bc/events?timeout=20&maxEvents=5 HTTP/1.1" 200 2209 "-" "-" 0.257753
[2021-03-03T17:31:20Z INFO  ya_market::negotiation::provider] AppSession id [provider_1-62] set for Agreement [P-5e6edb09a5fbbff3c3d07b0942ca78eeb0131bf074d93ae99d97e22c2ace0e3d].
[2021-03-03T17:31:20Z INFO  ya_market::negotiation::provider] Provider 'key_5629daf0e18648d9a5372e13d8de839b.json' [0xd1d84f0e28d6fedf03c73151f98df95139700aa7] approved Agreement [P-5e6edb09a5fbbff3c3d07b0942ca78eeb0131bf074d93ae99d97e22c2ace0e3d]. Waiting for commit from Requestor [0x63fc2ad3d021a4d7e64323529a55a9442c444da0].
[2021-03-03T17:31:20Z WARN  ya_activity::provider::service] Agreement 5e6edb09a5fbbff3c3d07b0942ca78eeb0131bf074d93ae99d97e22c2ace0e3d is not Approved. Current state: Pending
[2021-03-03T17:31:20Z DEBUG ya_service_bus::typed] Call to CreateActivity failed: Bad request: Agreement 5e6edb09a5fbbff3c3d07b0942ca78eeb0131bf074d93ae99d97e22c2ace0e3d is not Approved. Current state: Pending
[2021-03-03T17:31:20Z DEBUG ya_market::protocol::negotiation::provider] Negotiation API: Agreement [R-5e6edb09a5fbbff3c3d07b0942ca78eeb0131bf074d93ae99d97e22c2ace0e3d] committed by [0x63fc2ad3d021a4d7e64323529a55a9442c444da0].
[2021-03-03T17:31:20Z DEBUG ya_market::db::dao::agreement_events] Event timestamp: 2021-03-03 17:31:20.147180540, type: Approved
[2021-03-03T17:31:20Z INFO  ya_market::negotiation::provider] Agreement [P-5e6edb09a5fbbff3c3d07b0942ca78eeb0131bf074d93ae99d97e22c2ace0e3d] approved (committed) by [0x63fc2ad3d021a4d7e64323529a55a9442c444da0].
```
This leads to an error on the requestor side (again, https://github.com/golemfactory/goth/pull/431/checks?check_run_id=2024210751):
```
E               ya_activity.exceptions.ApiException: (400)
E               Reason: Bad Request
E               HTTP response headers: <CIMultiDictProxy('Content-Length': '141', 'Content-Type': 'application/json', 'Date': 'Wed, 03 Mar 2021 17:31:20 GMT')>
E               HTTP response body: {"message":"Bad request: Agreement 5e6edb09a5fbbff3c3d07b0942ca78eeb0131bf074d93ae99d97e22c2ace0e3d is not Approved. Current state: Pending"}
```