### PR TITLE
Remove poetry virtual env at the end of test workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -51,3 +51,7 @@ jobs:
       - name: Remove test logs
         if: always()
         run: rm -rf /tmp/goth-tests
+
+      # Only relevant for self-hosted runners
+      - name: Remove poetry virtual env
+        run: poetry env remove python3.8

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,4 +54,8 @@ jobs:
 
       # Only relevant for self-hosted runners
       - name: Remove poetry virtual env
+        if: always()
+        # Python version below should agree with the version set up by this job.
+        # In future we'll be able to use the `--all` flag here to remove envs for
+        # all Python versions (https://github.com/python-poetry/poetry/issues/3208).
         run: poetry env remove python3.8


### PR DESCRIPTION
Resolves #450

This PR adds a step that removes the virtual env at the end of the workflow:
https://github.com/golemfactory/goth/pull/449/checks?check_run_id=2093201699#step:10:1

And the next run of this workflow is forced to create a fresh virtual env and install all dependencies:
https://github.com/golemfactory/goth/pull/449/checks?check_run_id=2093246848#step:5:1