### PR TITLE
Add assertion monitor to the command output

### DIFF
--- a/goth/api_monitor/monitor_addon.py
+++ b/goth/api_monitor/monitor_addon.py
@@ -37,7 +37,7 @@ class MonitorAddon:
         """Log an API event and add it to the monitor."""
 
         self._logger.debug("%s", event)
-        self._monitor.add_event(event)
+        self._monitor.add_event_sync(event)
 
     def request(self, flow: HTTPFlow) -> None:
         """Register a request."""

--- a/goth/assertions/assertions.py
+++ b/goth/assertions/assertions.py
@@ -41,7 +41,7 @@ else:
 AssertionFunction = Callable[[EventStream[E]], Coroutine]
 
 
-class Assertion(AsyncIterable[E]):  # Awaitable[Any]):
+class Assertion(AsyncIterable[E]):
     """A class for executing assertion coroutines.
 
     An instance of this class wraps a coroutine (called the "assertion coroutine")

--- a/goth/assertions/assertions.py
+++ b/goth/assertions/assertions.py
@@ -41,12 +41,11 @@ else:
 AssertionFunction = Callable[[EventStream[E]], Coroutine]
 
 
-class Assertion(AsyncIterable[E]):
+class Assertion(AsyncIterable[E]):  # Awaitable[Any]):
     """A class for executing assertion coroutines.
 
-    An instance of this class wraps a coroutine function (called the
-    "assertion coroutine") and provides an asynchronous generator of
-    events that the assertion coroutine processes.
+    An instance of this class wraps a coroutine (called the "assertion coroutine")
+    and provides an asynchronous generator of events that this coroutine processes.
     After creating an instance of this class, its client should await
     the `update_events()` method each time a new event is appended to the list
     of events (the list is passed as an argument to `Assertion()`).
@@ -98,13 +97,20 @@ class Assertion(AsyncIterable[E]):
         if self.started:
             raise RuntimeError("Assertion already started")
 
-        def on_done(*args) -> None:
-            """Notify the tasks waiting until this assertion updates."""
-            self._notify_update_events()
+        async def func_wrapper():
+            """Ensure `_notify_update_events` is called after processing each event.
+
+            See also comments in `_create_generator()`.
+            """
+            try:
+                return await self._func(self)
+            except asyncio.CancelledError:
+                raise AssertionError("Assertion cancelled")
+            finally:
+                self._notify_update_events()
 
         assert self._func is not None
-        self._task = asyncio.create_task(self._func(self))
-        self._task.add_done_callback(on_done)
+        self._task = asyncio.create_task(func_wrapper())
         self._ready = asyncio.Event()
         self._processed = asyncio.Event()
         return self._task
@@ -126,27 +132,52 @@ class Assertion(AsyncIterable[E]):
     @property
     def accepted(self) -> bool:
         """Return `True` iff this assertion finished execution successfuly."""
-        return self.started and self._task.done() and self._task.exception() is None
+        return (
+            self._task is not None
+            and self._task.done()
+            and self._task.exception() is None
+        )
 
     @property
     def failed(self) -> bool:
         """Return `True` iff this assertion finished execution by failing."""
-        return self.started and self._task.done() and self._task.exception() is not None
+        return (
+            self._task is not None
+            and self._task.done()
+            and self._task.exception() is not None
+        )
 
-    async def result(self) -> Any:
+    def result(self) -> Any:
         """Return the result of this assertion.
 
-        If the assertion succeeded its result will be returned.
-        If it failed, the exception will be raised.
-        If the assertion hasn't finished yet, `None` will be returned.
-        If it hasn't been started, `asyncio.InvalidStateError` will be raised.
+        The semantics is similar to that of the `result()` method of `asyncio.Task`
+        (https://docs.python.org/3/library/asyncio-task.html#task-object):
+        If the assertion is done, the result of the assertion coroutine is returned
+        or the exception raised by the coroutine is re-raised.
+        If the assertion is not done (in particular, if hasn't been started) then
+        this method raises `asyncio.InvalidStateError`.
         """
-        if not self.started:
+        if not self._task:
             raise asyncio.InvalidStateError("Assertion not started")
 
-        if self._task.done():
+        return self._task.result()
+
+    async def wait_for_result(self, timeout: Optional[float] = None) -> Any:
+        """Wait until this assertion's result becomes available and return it.
+
+        Optional `timeout` is in seconds, `None` means to wait indefinitely
+        (this is the default).
+        """
+
+        if timeout is None:
             return await self._task
-        return None
+
+        try:
+            return await asyncio.wait_for(self._task, timeout=timeout)
+        finally:
+            # This is to retrieve exception from `self._task` so no unretrieved
+            # exceptions are reported when the event loop closes.
+            _ = self._task.exception()
 
     async def update_events(self, events_ended: bool = False) -> None:
         """Notify the assertion that a new event has been added."""
@@ -183,6 +214,8 @@ class Assertion(AsyncIterable[E]):
 
     def _notify_update_events(self) -> None:
         """Notify tasks waiting in `update_events()` that the update is processed."""
+        if not self._ready or not self._processed:
+            raise asyncio.InvalidStateError("Assertion not started")
         self._ready.clear()
         self._processed.set()
 
@@ -209,5 +242,19 @@ class Assertion(AsyncIterable[E]):
             #
             # In case the control does not return (since the events end or
             # the assertion coroutine raises an exception), `_notify_update_events()`
-            # is called in the done callback for the coroutine task.
+            # must be called after returning from the assertion coroutine.
             self._notify_update_events()
+
+    # def __await__(self) -> Generator[Any, None, Any]:
+    #     """Make this assertion `Awaitable`.
+    #
+    #     The expression `await assertion` waits until `assertion` is done and then
+    #     yields `assertion.result()` (which may raise an exception if the assertion
+    #     failed).
+    #     """
+    #
+    #     if not self._task:
+    #         raise asyncio.InvalidStateError("Assertion not started")
+    #
+    #     return self._task.__await__()
+    #     # return self._task.__iter__()

--- a/goth/assertions/assertions.py
+++ b/goth/assertions/assertions.py
@@ -168,6 +168,8 @@ class Assertion(AsyncIterable[E]):  # Awaitable[Any]):
         Optional `timeout` is in seconds, `None` means to wait indefinitely
         (this is the default).
         """
+        if not self._task:
+            raise asyncio.InvalidStateError("Assertion not started")
 
         if timeout is None:
             return await self._task
@@ -244,17 +246,3 @@ class Assertion(AsyncIterable[E]):  # Awaitable[Any]):
             # the assertion coroutine raises an exception), `_notify_update_events()`
             # must be called after returning from the assertion coroutine.
             self._notify_update_events()
-
-    # def __await__(self) -> Generator[Any, None, Any]:
-    #     """Make this assertion `Awaitable`.
-    #
-    #     The expression `await assertion` waits until `assertion` is done and then
-    #     yields `assertion.result()` (which may raise an exception if the assertion
-    #     failed).
-    #     """
-    #
-    #     if not self._task:
-    #         raise asyncio.InvalidStateError("Assertion not started")
-    #
-    #     return self._task.__await__()
-    #     # return self._task.__iter__()

--- a/goth/runner/__init__.py
+++ b/goth/runner/__init__.py
@@ -200,7 +200,7 @@ class Runner:
             ports=ports,
             assertions_module=self.api_assertions_module,
         )
-        self._exit_stack.enter_context(run_proxy(self.proxy))
+        await self._exit_stack.enter_async_context(run_proxy(self.proxy))
 
         # Collect all agent enabled probes and start them in parallel
         awaitables = []

--- a/goth/runner/log_monitor.py
+++ b/goth/runner/log_monitor.py
@@ -10,8 +10,7 @@ from typing import Iterator, Optional, Sequence
 
 from func_timeout.StoppableThread import StoppableThread
 
-from goth.assertions.monitor import EventMonitor
-from goth.assertions.operators import eventually
+from goth.assertions.monitor import E, WaitableEventMonitor
 from goth.runner.exceptions import StopThreadException
 from goth.runner.log import LogConfig
 
@@ -115,30 +114,53 @@ def _create_file_logger(config: LogConfig) -> logging.Logger:
     return logger_
 
 
-class LogEventMonitor(EventMonitor[LogEvent]):
+class PatternMatchingWaitableMonitor(WaitableEventMonitor[E]):
+    """A `WaitableEventMonitor` that can wait for events that match regex patterns."""
+
+    def event_str(self, event: E) -> str:
+        """Return the string associated with `event` on which to perform matching."""
+        return str(event)
+
+    async def wait_for_pattern(self, pattern: str, timeout: float = 1000) -> E:
+        """Wait for an event with string representation matching `pattern`.
+
+        The semantics for this method is as for
+        `EventProgressMonitor.wait_for_event(predicate, timeout)`, with `predicate(e)`
+        being true iff `event_str(e)` matches `pattern`, for any event `e`.
+        """
+
+        regex = re.compile(pattern)
+        event = await self.wait_for_event(
+            lambda e: regex.match(self.event_str(e)) is not None, timeout
+        )
+        return event
+
+
+class LogEventMonitor(PatternMatchingWaitableMonitor[LogEvent]):
     """Log buffer supporting logging to a file and waiting for a line pattern match.
 
     `log_config` parameter holds the configuration of the file logger.
     Consecutive values are interpreted as lines by splitting them on the new line
     character.
-    Internally it uses an asyncio task to read the stream and add lines to the buffer.
+    Internally it uses a thread to read the stream and add lines to the buffer.
     """
 
     _buffer_task: Optional[StoppableThread]
     _file_logger: logging.Logger
     _in_stream: Iterator[bytes]
-    _last_checked_line: int
-    """The index of the last line examined while waiting for log messages.
 
-    Subsequent calls to `wait_for_agent_log()` will only look at lines that
-    were logged after this line.
-    """
-
-    def __init__(self, name: str, log_config: LogConfig):
+    def __init__(self, name: str, log_config: Optional[LogConfig] = None):
         super().__init__(name)
-        self._file_logger = _create_file_logger(log_config)
+        if log_config:
+            self._file_logger = _create_file_logger(log_config)
+        else:
+            self._file_logger = logging.getLogger(name)
         self._buffer_task = None
-        self._last_checked_line = -1
+        self._loop = asyncio.get_event_loop()
+
+    def event_str(self, event: LogEvent) -> str:
+        """Return the string associated with `event` on which to perform matching."""
+        return event.message
 
     @property
     def events(self) -> Sequence[LogEvent]:
@@ -173,7 +195,8 @@ class LogEventMonitor(EventMonitor[LogEvent]):
                     self._file_logger.info(line)
 
                     event = LogEvent(line)
-                    self.add_event(event)
+                    self.add_event_sync(event)
+
         except StopThreadException:
             return
 
@@ -187,42 +210,10 @@ class LogEventMonitor(EventMonitor[LogEvent]):
         Subsequent calls will examine all log entries gathered since
         the previous call returned and then wait for up to `timeout` seconds.
         """
-        regex = re.compile(pattern)
-
-        def predicate(log_event) -> bool:
-            return regex.match(log_event.message) is not None
-
-        # First examine log lines already seen
-        while self._last_checked_line + 1 < len(self.events):
-            self._last_checked_line += 1
-            event = self.events[self._last_checked_line]
-            if predicate(event):
-                logger.debug(
-                    "Found match in past log lines. pattern=%s, match=%s",
-                    pattern,
-                    event.message,
-                )
-                return event
-
-        # Otherwise create an assertion that waits for a matching line...
-        async def wait_for_matching_line(stream) -> LogEvent:
-            try:
-                log_event = await eventually(stream, predicate, timeout=timeout)
-                return log_event
-            finally:
-                self._last_checked_line = len(stream.past_events) - 1
-
-        assertion = self.add_assertion(wait_for_matching_line, logging.DEBUG)
-
-        # ... and wait until the assertion completes
-        while not assertion.done:
-            await asyncio.sleep(0.1)
-
-        result: LogEvent = await assertion.result()
-        if result:
-            logger.debug(
-                "Log assertion completed with a match. pattern=%s, match=%s",
-                pattern,
-                result.message,
-            )
-        return result
+        event = await self.wait_for_pattern(pattern, timeout)
+        logger.debug(
+            "Log assertion completed with a match. pattern=%s, match=%s",
+            pattern,
+            event.message,
+        )
+        return event

--- a/goth/runner/probe.py
+++ b/goth/runner/probe.py
@@ -36,7 +36,7 @@ from goth.runner.container.yagna import (
 )
 from goth.runner.exceptions import KeyAlreadyExistsError
 from goth.runner.log import LogConfig, monitored_logger
-from goth.runner.log_monitor import PatternMatchingWaitableMonitor
+from goth.runner.log_monitor import PatternMatchingEventMonitor
 from goth.runner import process
 
 
@@ -252,18 +252,18 @@ class Probe(abc.ABC):
         command: str,
         env: Optional[Dict[str, str]] = None,
         command_timeout: float = 300,
-    ) -> Iterator[Tuple[asyncio.Task, PatternMatchingWaitableMonitor]]:
+    ) -> Iterator[Tuple[asyncio.Task, PatternMatchingEventMonitor]]:
         """Run `command` on host in given `env` and with optional `timeout`.
 
         The command is run in the environment extending `env` with variables needed
         to communicate with the daemon running in this probe's container.
 
-        Internally, this method used `process.run_command()` to run `command`.
+        Internally, this method uses `process.run_command()` to run `command`.
         The argument `command_timeout` is passed as the `timeout` parameter to
         `process.run_command()`.
 
         Returns the `asyncio` task that logs output from the command, and an event
-        monitor that observes lines out output produced by the command.
+        monitor that observes lines of output produced by the command.
 
         The task can be awaited in order to wait until the command completes.
         The monitor can be used for asserting properties of the command's output.
@@ -271,7 +271,7 @@ class Probe(abc.ABC):
         cmd_env = {**env} if env is not None else {}
         self.set_agent_env_vars(cmd_env)
 
-        cmd_monitor = PatternMatchingWaitableMonitor(name="command output")
+        cmd_monitor = PatternMatchingEventMonitor(name="command output")
         cmd_monitor.start()
 
         try:

--- a/goth/runner/process.py
+++ b/goth/runner/process.py
@@ -28,7 +28,11 @@ async def run_command(
 
     :param args: sequence consisting of the program to run along with its arguments
     :param env: dict with environment for the command
-    :param log_prefix: prefix for log lines emitted. Default: name of the command
+    :param log_level: logging level at which command output will be logged
+    :param cmd_logger: optional logger instance used to log output from the command;
+        if not set the default module logger will be used
+    :param log_prefix: prefix for log lines with command output; ignored if `cmd_logger`
+        is specified. Default: name of the command
     :param timeout: timeout for the command, in seconds. Default: 15 minutes
     """
     logger.info("Running local command: %s", " ".join(args))

--- a/goth/runner/process.py
+++ b/goth/runner/process.py
@@ -17,8 +17,9 @@ async def run_command(
     args: Sequence[str],
     env: Optional[dict] = None,
     log_level: Optional[int] = logging.DEBUG,
+    cmd_logger: Optional[logging.Logger] = None,
     log_prefix: Optional[str] = None,
-    timeout: int = RUN_COMMAND_DEFAULT_TIMEOUT,
+    timeout: float = RUN_COMMAND_DEFAULT_TIMEOUT,
 ) -> None:
     """Run a command in a subprocess with timeout and logging.
 
@@ -32,8 +33,12 @@ async def run_command(
     """
     logger.info("Running local command: %s", " ".join(args))
 
-    if log_prefix is None:
-        log_prefix = f"[{args[0]}] "
+    if cmd_logger:
+        log_prefix = ""
+    else:
+        cmd_logger = logger
+        if log_prefix is None:
+            log_prefix = f"[{args[0]}] "
 
     async def _run_command():
 
@@ -43,7 +48,7 @@ async def run_command(
 
         while not proc.stdout.at_eof():
             line = await proc.stdout.readline()
-            logger.log(log_level, "%s%s", log_prefix, line.decode("utf-8").rstrip())
+            cmd_logger.log(log_level, "%s%s", log_prefix, line.decode("utf-8").rstrip())
 
         return_code = await proc.wait()
         if return_code:

--- a/test/goth/assertions/test_assertions.py
+++ b/test/goth/assertions/test_assertions.py
@@ -524,7 +524,7 @@ async def test_wait_for_result_timeout_raises():
     with pytest.raises(asyncio.TimeoutError):
         await assertion.wait_for_result(timeout=0.1)
 
-    # The is cancelled and should fail with AssertionError("Assertion cancelled")
+    # Assertion is cancelled and should fail with AssertionError("Assertion cancelled")
     assert assertion.failed
     with pytest.raises(AssertionError) as error:
         _ = assertion.result()

--- a/test/goth/assertions/test_monitor.py
+++ b/test/goth/assertions/test_monitor.py
@@ -5,7 +5,7 @@ import asyncio
 import pytest
 
 from goth.assertions import EventStream
-from goth.assertions.monitor import EventMonitor, WaitableEventMonitor
+from goth.assertions.monitor import EventMonitor
 
 
 # Events are just integers
@@ -113,7 +113,7 @@ async def test_assertions():
 async def test_not_started_raises_on_add_event():
     """Test whether `add_event()` invoked before starting the monitor raises error."""
 
-    monitor: EventMonitor[int] = EventMonitor()
+    monitor = EventMonitor()
 
     with pytest.raises(RuntimeError):
         await monitor.add_event(1)
@@ -123,7 +123,7 @@ async def test_not_started_raises_on_add_event():
 async def test_stopped_raises_on_add_event():
     """Test whether `add_event()` invoked after stopping the monitor raises error."""
 
-    monitor: EventMonitor[int] = EventMonitor()
+    monitor = EventMonitor()
 
     monitor.start()
     await monitor.stop()
@@ -136,7 +136,7 @@ async def test_stopped_raises_on_add_event():
 async def test_waitable_monitor():
     """Test if `WaitableMonitor.wait_for_event()` respects event ordering."""
 
-    monitor = WaitableEventMonitor()
+    monitor = EventMonitor()
     monitor.start()
 
     events = []
@@ -167,7 +167,7 @@ async def test_waitable_monitor():
 async def test_waitable_monitor_timeout_error():
     """Test if `WaitableMonitor.wait_for_event()` raises `TimeoutError` on timeout."""
 
-    monitor: WaitableEventMonitor[int] = WaitableEventMonitor()
+    monitor = EventMonitor()
     monitor.start()
 
     with pytest.raises(asyncio.TimeoutError):
@@ -180,7 +180,7 @@ async def test_waitable_monitor_timeout_error():
 async def test_waitable_monitor_timeout_success():
     """Test if `WaitableMonitor.wait_for_event()` return success before timeout."""
 
-    monitor = WaitableEventMonitor()
+    monitor = EventMonitor()
     monitor.start()
 
     async def worker_task():


### PR DESCRIPTION
Resolves #452 

Main changes in this PR:

### Changes in `Assertion` API

1. The `Assertion` class now has a method that can be used to wait until an assertion finishes (either succeeding or failing),
with optional timeout:
```
   tasks_computed: Assertion = command_monitor.add_assertion(...)
   ...
   # Wait up to 60 s until the assertion`tasks_computed` finishes.
   tasks_computed.wait_for_result(timeout=60)
```

2. The `result()` method behaves as `asyncio.Task.result()` in that it raises `asyncio.InvalidStateError` if the assertion is not done.

### Changes in the `EventMonitor` API

1. The method `add_event()` is now `async`. This ensures that `asyncio` tasks waiting for events are notified after each new event is added (this wasn't the case before this change which caused some issues when waiting for matching lines in container logs). A non-async variant `add_event_sync()` is added.

2. Assertions are started already in `add_assertion()` method, not in `_check_assertions()`. This ensures that `wait_for_result()` can be called on an assertion before any events are added to the monitor it is added to.

### `WaitableEventMonitor` and `PatternMatchingWaitableMonitor`

The functionality of waiting for a particular log line in a container log has been extracted from `LogEventMonitor` to two new classes in the `EventMonitor` hierarchy: `WaitableEventMonitor` with the method `wait_for_event(predicate, timeout)` and its subclass `PatternMatchingWaitableMonitor` with `wait_for_patttern(pattern, timeout`). `LogEventMonitor` now inherits from the latter class. 

This refactoring will allow use to reuse pattern-matching functionality for monitoring the output from a command run on the host.

### Return an `EventMonitor` for command output from `Probe.run_command_on_host()`.

1. The method `Probe.run_command_on_host()` now returns a `PatternMatchingWaitableMonitor` that can be used to add assertions expressing the properties of the command's output (each line of the command's stdout/stderr becomes an event for the monitor).

2. `Probe.run_command_on_host()` is now an `AsyncContextManager`. Exiting the context stops the associated event monitor and waits for the running command to complete.