### PR TITLE
Include test directory in logger names in `log_monitor._create_file_logger()`

### DIFF
--- a/goth/runner/log_monitor.py
+++ b/goth/runner/log_monitor.py
@@ -108,7 +108,8 @@ def _create_file_logger(config: LogConfig) -> logging.Logger:
         delay=True,
     )
     handler.setFormatter(config.formatter)
-    logger_ = logging.getLogger(str(config.file_name))
+    logger_name = f"{config.base_dir}.{config.file_name}"
+    logger_ = logging.getLogger(logger_name)
     logger_.setLevel(config.level)
     logger_.addHandler(handler)
     logger_.propagate = False


### PR DESCRIPTION
Resolves #459 

Use test directory name together with the container name as the logger name for `logging.getLogger()` in the function `log_monitor._create_file_logger()`. This will ensure that for distinct test cases in a single session distinct logger instances are returned.