### PR TITLE
Update zsync-mock to latest version

### DIFF
--- a/goth/default-assets/docker/docker-compose.yml
+++ b/goth/default-assets/docker/docker-compose.yml
@@ -21,7 +21,7 @@ services:
             - "8545:8545"
 
     zksync:
-        image: docker.pkg.github.com/golemfactory/yagna-zksync/yagna-zksync-mock:7a25ed913d4a
+        image: docker.pkg.github.com/golemfactory/yagna-zksync/yagna-zksync-mock:f6d0cf02f6bc
         ports:
             - "3030:3030"
         environment:

--- a/goth/node.py
+++ b/goth/node.py
@@ -29,7 +29,7 @@ def node_environment(
         "RUST_LOG": "debug,tokio_core=info,tokio_reactor=info,hyper=info",
         "YA_PAYMENT_NETWORK": "rinkeby",
         "YAGNA_API_URL": YAGNA_REST_URL.substitute(host="0.0.0.0"),
-        "ZKSYNC_FAUCET_ADDR": "http://zksync:3030/donate",
+        "ZKSYNC_FAUCET_ADDR": "http://zksync:3030/zk/donatex",
         "ZKSYNC_RINKEBY_RPC_ADDRESS": "http://zksync:3030",
         # left for compatibility with yagna prior to commit 800efe13
         "ZKSYNC_RPC_ADDRESS": "http://zksync:3030",

--- a/test/yagna/e2e/assets/docker/docker-compose.yml
+++ b/test/yagna/e2e/assets/docker/docker-compose.yml
@@ -21,7 +21,7 @@ services:
             - "8545:8545"
 
     zksync:
-        image: docker.pkg.github.com/golemfactory/yagna-zksync/yagna-zksync-mock:515b66be9f96
+        image: docker.pkg.github.com/golemfactory/yagna-zksync/yagna-zksync-mock:f6d0cf02f6bc
         ports:
             - "3030:3030"
         environment:

--- a/test/yagna/module/payments/test_zero_amount_txs.py
+++ b/test/yagna/module/payments/test_zero_amount_txs.py
@@ -100,9 +100,11 @@ async def test_zero_amount_invoice_is_settled(
         counterproposal_id = await requestor.counter_proposal(
             subscription_id, demand, proposal
         )
+        logger.info("Counter proposal %s", counterproposal_id)
         await provider.wait_for_proposal_accepted()
 
         new_proposals = await requestor.wait_for_proposals(subscription_id, (provider,))
+        logger.info(new_proposals)
         new_proposal = new_proposals[0]
         assert new_proposal.prev_proposal_id == counterproposal_id
 


### PR DESCRIPTION
Update zksync mock to latest version, this includes:
- Bug fixes
- Removal of GNT token
- Update of the mocked faucet /donate url ( to match yagna )

Also added some logging for a flaky build that failed.