### PR TITLE
Fixes for `OrderedDict mutated during iteration` and for `python -m goth` crashing

### DIFF
--- a/goth/__main__.py
+++ b/goth/__main__.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
     parser_cfg.set_defaults(function=create_config)
 
     args = parser.parse_args()
-    if args.function:
+    try:
         args.function(args)
-    else:
+    except AttributeError:
         parser.print_help()

--- a/goth/assertions/monitor.py
+++ b/goth/assertions/monitor.py
@@ -247,7 +247,7 @@ class EventMonitor(Generic[E]):
             else "EndOfEvents"
         )
 
-        for a, level in self.assertions.items():
+        for a, level in list(self.assertions.items()):
 
             if a.done:
                 continue

--- a/test/goth/assertions/test_monitor.py
+++ b/test/goth/assertions/test_monitor.py
@@ -195,6 +195,10 @@ async def test_waitable_monitor_timeout_success():
 
 @pytest.mark.asyncio
 async def test_add_assertion_while_checking():
+    """Test if adding an assertion while iterating over existing assertions works.
+
+    See https://github.com/golemfactory/goth/issues/464
+    """
 
     monitor = EventMonitor()
 
@@ -216,5 +220,3 @@ async def test_add_assertion_while_checking():
     monitor.add_assertion(assert_all_positive)
 
     await monitor.stop()
-
-

--- a/test/goth/assertions/test_monitor.py
+++ b/test/goth/assertions/test_monitor.py
@@ -191,3 +191,30 @@ async def test_waitable_monitor_timeout_success():
 
     await monitor.wait_for_event(lambda e: e == 1, timeout=1.0)
     await monitor.stop()
+
+
+@pytest.mark.asyncio
+async def test_add_assertion_while_checking():
+
+    monitor = EventMonitor()
+
+    async def long_running_assertion_1(stream: Events):
+        async for _ in stream:
+            await asyncio.sleep(0.05)
+
+    async def long_running_assertion_2(stream: Events):
+        async for _ in stream:
+            await asyncio.sleep(0.05)
+
+    monitor.add_assertion(long_running_assertion_1)
+    monitor.add_assertion(long_running_assertion_2)
+    monitor.start()
+
+    await monitor.add_event(1)
+    await asyncio.sleep(0)
+    # Add a new assertion while long_running_assertions are still being checked
+    monitor.add_assertion(assert_all_positive)
+
+    await monitor.stop()
+
+


### PR DESCRIPTION
Quick fixes for two bugs unrelated one to another.

Resolves #464 
Resolves #465 
