### PR TITLE
Optional `name` argument for `Assertion()`

### DIFF
--- a/goth/assertions/monitor.py
+++ b/goth/assertions/monitor.py
@@ -99,11 +99,14 @@ class EventMonitor(Generic[E]):
         self._worker_task = None
 
     def add_assertion(
-        self, assertion_func: AssertionFunction[E], log_level: LogLevel = logging.INFO
+        self,
+        assertion_func: AssertionFunction[E],
+        name: Optional[str] = None,
+        log_level: LogLevel = logging.INFO,
     ) -> Assertion:
         """Add an assertion function to this monitor."""
 
-        assertion = Assertion(self._events, assertion_func)
+        assertion = Assertion(self._events, assertion_func, name=name)
         assertion.start()
         self._logger.debug("Assertion '%s' started", assertion.name)
         self.assertions[assertion] = log_level
@@ -332,7 +335,7 @@ class EventMonitor(Generic[E]):
                     return e
             raise AssertionError("No matching event occurred")
 
-        assertion = self.add_assertion(wait_for_match, logging.DEBUG)
+        assertion = self.add_assertion(wait_for_match, log_level=logging.DEBUG)
 
         # ... and wait until the assertion completes
         return await assertion.wait_for_result(timeout=timeout)

--- a/test/goth/assertions/test_assertions.py
+++ b/test/goth/assertions/test_assertions.py
@@ -529,3 +529,34 @@ async def test_wait_for_result_timeout_raises():
     with pytest.raises(AssertionError) as error:
         _ = assertion.result()
     assert "Assertion cancelled" in str(error)
+
+
+async def toplevel(_stream):
+    """Do nothing, be just a function with one sentence, imperative mode docstring."""
+    ...
+
+
+@pytest.mark.asyncio
+async def test_assertion_names():
+    """Test if assertion names are constructed correctly."""
+
+    async def inner(_stream):
+        ...
+
+    def make_assertion(_arg):
+        async def innermost(_stream):
+            ...
+
+        return innermost
+
+    a1 = Assertion([], toplevel)
+    assert a1.name == f"{__name__}.toplevel"
+
+    a2 = Assertion([], inner)
+    assert a2.name == f"{__name__}.test_assertion_names.inner"
+
+    a3 = Assertion([], make_assertion(1))
+    assert a3.name == f"{__name__}.test_assertion_names.make_assertion.innermost"
+
+    a4 = Assertion([], toplevel, name="I'm an assertion")
+    assert a4.name == "I'm an assertion"


### PR DESCRIPTION
An object created by `Assertion(func)` has a `name` attribute that is computed from `__module__` and `__qualname__` attributes
of `func`. This works only if `func` refers to a definition of the form `async def func(...)`, otherwise, `func.__module__` and `func.__qualname__` are not available. It's sometimes convenient to pass as the value of `func` an object that does not
refer to an `async def`, for example a result of `functools.partial(func, args)`. Changes in this PR allow us to set the name of an assertion explicitly:
```
   a = Assertion(partial(func, 1, "x"), name="an assertion")
```
