### PR TITLE
Use StoppableThread for mitmproxy

### DIFF
--- a/goth/runner/exceptions.py
+++ b/goth/runner/exceptions.py
@@ -19,7 +19,7 @@ class KeyAlreadyExistsError(CommandError):
     """Specific duplicate key subclass of the CommandError."""
 
 
-class StopThreadException(Exception):
+class StopThreadException(BaseException):
     """Exception used to stop a running `StoppableThread`."""
 
 


### PR DESCRIPTION
This resolves an issue with finished/failed tests hanging indefinitely, waiting for the proxy thread to finish work (example of one such test run: https://github.com/golemfactory/goth/actions/runs/725767107). From my observations this was happening in cases when there were no messages exchanged through the proxy.