### PR TITLE
Variant of `payment driver` PR that uses custom yagna for one test

### DIFF
--- a/goth/runner/cli/yagna_payment_cmd.py
+++ b/goth/runner/cli/yagna_payment_cmd.py
@@ -45,6 +45,30 @@ class PaymentStatus:
         )
 
 
+@dataclass(frozen=True)
+class Network:
+    """Contains information about `Network`."""
+
+    default_token: str
+    tokens: Dict[str, str]
+
+
+@dataclass(frozen=True)
+class Driver:
+    """Contains driver details fields."""
+
+    default_network: str
+    networks: Dict[str, Network]
+
+    @staticmethod
+    def from_dict(source: dict):
+        """Parse a dict into an instance of `Driver` class."""
+        return Driver(
+            default_network=source["default_network"],
+            networks={key: Network(**val) for key, val in source["networks"].items()},
+        )
+
+
 class YagnaPaymentMixin:
     """A mixin class that adds support for `<yagna-cmd> payment` commands."""
 
@@ -97,3 +121,15 @@ class YagnaPaymentMixin:
         args = make_args("payment", "status", driver.name, data_dir=data_dir)
         output = self.run_json_command(Dict, *args)
         return PaymentStatus.from_dict(output)
+
+    def payment_drivers(
+        self: CommandRunner,
+    ) -> Dict[str, Driver]:
+        """Run `<cmd> payment drivers` without any extra args.
+
+        Parse the command's output as a `Dict[str, Driver]` and return it.
+        """
+
+        args = make_args("payment", "drivers")
+        output = self.run_json_command(Dict, *args)
+        return {key: Driver.from_dict(val) for key, val in output.items()}

--- a/test/goth/runner/cli/test_yagna_payment_cmd.py
+++ b/test/goth/runner/cli/test_yagna_payment_cmd.py
@@ -43,3 +43,12 @@ def test_payment_status_with_address(yagna_container):
 
     status = yagna.payment_status()
     assert status
+
+
+def test_payment_drivers(yagna_container):
+    """Test `payment drivers` subcommand."""
+
+    yagna = Cli(yagna_container).yagna
+
+    drivers = yagna.payment_drivers()
+    assert drivers

--- a/test/goth/runner/cli/test_yagna_payment_cmd.py
+++ b/test/goth/runner/cli/test_yagna_payment_cmd.py
@@ -43,12 +43,3 @@ def test_payment_status_with_address(yagna_container):
 
     status = yagna.payment_status()
     assert status
-
-
-def test_payment_drivers(yagna_container):
-    """Test `payment drivers` subcommand."""
-
-    yagna = Cli(yagna_container).yagna
-
-    drivers = yagna.payment_drivers()
-    assert drivers

--- a/test/yagna/module/payments/test_payment_driver_list_cmd.py
+++ b/test/yagna/module/payments/test_payment_driver_list_cmd.py
@@ -2,7 +2,7 @@
 
 import logging
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 import pytest
 
@@ -15,8 +15,32 @@ from goth.runner import Runner
 from goth.runner.container.payment import PaymentIdPool
 from goth.runner.container.yagna import YagnaContainerConfig
 from goth.runner.requestor import RequestorProbeWithApiSteps
+from goth.runner.container.build import YagnaBuildEnvironment
+
 
 logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def yagna_build_env(
+    assets_path: Path,
+    yagna_binary_path: Optional[Path],
+    yagna_branch: Optional[str],
+    # yagna_commit_hash: Optional[str],
+    deb_package: Optional[Path],
+    yagna_release: Optional[str],
+) -> YagnaBuildEnvironment:
+    """Override the default fixture to force using specific yagna commit."""
+
+    """Fixture which provides the build environment for yagna Docker images."""
+    return YagnaBuildEnvironment(
+        docker_dir=assets_path / "docker",
+        binary_path=yagna_binary_path,
+        branch=yagna_branch,
+        commit_hash="c4d1dd7",
+        deb_path=deb_package,
+        release_tag=yagna_release,
+    )
 
 
 def _topology(payment_id_pool: PaymentIdPool) -> List[YagnaContainerConfig]:

--- a/test/yagna/module/payments/test_payment_driver_list_cmd.py
+++ b/test/yagna/module/payments/test_payment_driver_list_cmd.py
@@ -12,10 +12,10 @@ from goth.address import (
 )
 from goth.node import node_environment
 from goth.runner import Runner
+from goth.runner.container.build import YagnaBuildEnvironment
 from goth.runner.container.payment import PaymentIdPool
 from goth.runner.container.yagna import YagnaContainerConfig
-from goth.runner.requestor import RequestorProbeWithApiSteps
-from goth.runner.container.build import YagnaBuildEnvironment
+from goth.runner.probe import RequestorProbe
 
 
 logger = logging.getLogger(__name__)
@@ -32,7 +32,6 @@ def yagna_build_env(
 ) -> YagnaBuildEnvironment:
     """Override the default fixture to force using specific yagna commit."""
 
-    """Fixture which provides the build environment for yagna Docker images."""
     return YagnaBuildEnvironment(
         docker_dir=assets_path / "docker",
         binary_path=yagna_binary_path,
@@ -53,7 +52,7 @@ def _topology(payment_id_pool: PaymentIdPool) -> List[YagnaContainerConfig]:
     return [
         YagnaContainerConfig(
             name="requestor",
-            probe_type=RequestorProbeWithApiSteps,
+            probe_type=RequestorProbe,
             environment=requestor_env,
             payment_id=payment_id_pool.get_id(),
         ),
@@ -73,7 +72,7 @@ async def test_payment_driver_list(
     topology = _topology(payment_id_pool)
 
     async with runner(topology):
-        requestor = runner.get_probes(probe_type=RequestorProbeWithApiSteps)[0]
+        requestor = runner.get_probes(probe_type=RequestorProbe)[0]
 
         res = requestor.cli.payment_drivers()
         assert res and res.items()

--- a/test/yagna/module/payments/test_payment_driver_list_cmd.py
+++ b/test/yagna/module/payments/test_payment_driver_list_cmd.py
@@ -1,0 +1,65 @@
+"""Tests payment driver list CLI command."""
+
+import logging
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from goth.address import (
+    PROXY_HOST,
+    YAGNA_REST_URL,
+)
+from goth.node import node_environment
+from goth.runner import Runner
+from goth.runner.container.payment import PaymentIdPool
+from goth.runner.container.yagna import YagnaContainerConfig
+from goth.runner.requestor import RequestorProbeWithApiSteps
+
+logger = logging.getLogger(__name__)
+
+
+def _topology(payment_id_pool: PaymentIdPool) -> List[YagnaContainerConfig]:
+    # Nodes are configured to communicate via proxy
+
+    requestor_env = node_environment(
+        rest_api_url_base=YAGNA_REST_URL.substitute(host=PROXY_HOST),
+    )
+
+    return [
+        YagnaContainerConfig(
+            name="requestor",
+            probe_type=RequestorProbeWithApiSteps,
+            environment=requestor_env,
+            payment_id=payment_id_pool.get_id(),
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_payment_driver_list(
+    assets_path: Path,
+    demand_constraints: str,
+    payment_id_pool: PaymentIdPool,
+    runner: Runner,
+    task_package_template: str,
+):
+    """Test just the requestor's CLI command, no need to setup provider."""
+
+    topology = _topology(payment_id_pool)
+
+    async with runner(topology):
+        requestor = runner.get_probes(probe_type=RequestorProbeWithApiSteps)[0]
+
+        res = requestor.cli.payment_drivers()
+        assert res and res.items()
+        driver = next(iter(res.values()), None)
+
+        assert driver.default_network, "Default network should be set"
+
+        network = driver.networks.get(driver.default_network, None)
+        assert network, "Network should belong to the Driver"
+        assert network.default_token, "Default taken should be set"
+
+        token = network.tokens.get(network.default_token, None)
+        assert token, "Token should belong to the Network"


### PR DESCRIPTION
A variant of #453 that uses a custom version of yagna (specified as commit hash in a fixture in `test_payment_driver_list_cmd.py`).

Rebased on `master` to avoid problems with mitmproxy shutdown in short-running tests (see #477).