### PR TITLE
Ensure assertion success/failure is reported in EventMonitor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ exclude= '/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|venv|\.svn|_build|
 
 [tool.poetry]
 name = "goth"
-version = "0.2.3"
+version = "0.2.4"
 description = "Golem Test Harness - integration testing framework"
 authors = ["Golem Factory <contact@golem.network>"]
 license = "GPL-3.0"

--- a/test/goth/runner/test_assertion_monitors.py
+++ b/test/goth/runner/test_assertion_monitors.py
@@ -1,0 +1,53 @@
+"""Unit tests related to the use of assertion monitors in Runner."""
+
+import asyncio
+from pathlib import Path
+import tempfile
+from unittest.mock import Mock
+
+import pytest
+
+from goth.assertions.monitor import EventMonitor
+from goth.runner import Runner, TemporalAssertionError
+
+
+@pytest.mark.asyncio
+async def test_check_assertions(caplog):
+    """Test the `Runner.check_assertion_errors()` method."""
+
+    runner = Runner(
+        base_log_dir=Path(tempfile.mkdtemp()),
+        compose_config=Mock(),
+    )
+
+    async def assertion(events):
+        async for _ in events:
+            break
+        async for _ in events:
+            raise AssertionError("Just failing")
+
+    idle_monitor = EventMonitor()
+    idle_monitor.start()
+    busy_monitor = EventMonitor()
+    busy_monitor.add_assertion(assertion)
+    busy_monitor.start()
+
+    await asyncio.sleep(0.1)
+    runner.check_assertion_errors(idle_monitor, busy_monitor)
+
+    await busy_monitor.add_event(1)
+    await asyncio.sleep(0.1)
+    runner.check_assertion_errors(idle_monitor, busy_monitor)
+
+    await busy_monitor.add_event(2)
+    await asyncio.sleep(0.1)
+    # Assertion failure should be logged at this point
+    assert any(record.levelname == "ERROR" for record in caplog.records)
+    # And `check_assertion_errors()` should raise an exception
+    with pytest.raises(TemporalAssertionError):
+        runner.check_assertion_errors(idle_monitor, busy_monitor)
+
+    await busy_monitor.stop()
+    await idle_monitor.stop()
+    with pytest.raises(TemporalAssertionError):
+        runner.check_assertion_errors(idle_monitor, busy_monitor)


### PR DESCRIPTION
# Summary of changes

### Ensure that assertion success or failure is logged by an event monitor.

Description copied from the docstring in a unit test case added in 9b967999af837a177be84a48336f0cf5e9fcbf43:
```
Test that assertion success and failure are logged.

This used to be a problem for assertions that do not succeed or fail
immediately after consuming an event. For example if an assertion
contains `asyncio.wait_for()` then it may raise an exception some time
after it consumed any event. After the failure, the monitor will not
feed new events to the assertion. But it should report the failure
(exactly once).
```

### Add optional list of `extra_monitors` to `Runner.check_assertion_errors()`

This would simplify checking errors in monitors created _ad hoc_, not associated with a probe or an agent.
For example, one `yapapi` integration test ends with:
```python
        for a in monitor.failed:
            raise a.result()
```
(https://github.com/golemfactory/yapapi/blob/d33d676081a7a29c30b695bb13f7b88c89bc9a46/tests/goth/test_resubscription.py#L190-L191).
After this change, one would be able to write instead:
```python
        runner.check_assertion_errors(monitor)
```

### Add colors to "Running test ..." and "Test finished ..." messages

A bonus. See e.g. https://github.com/golemfactory/goth/runs/2398454134?check_suite_focus=true#step:9:17 and https://github.com/golemfactory/goth/runs/2398454134?check_suite_focus=true#step:9:110.