### PR TITLE
[probe] fix regex for wating for yagna REST API

### DIFF
--- a/goth/runner/log_monitor.py
+++ b/goth/runner/log_monitor.py
@@ -47,7 +47,7 @@ class LogEvent:
 
             try:
                 formatted_time = datetime.strptime(
-                    result["datetime"], "%Y-%m-%dT%H:%M:%SZ"
+                    result["datetime"], "%Y-%m-%dT%H:%M:%S.%f%z"
                 )
             except Exception:
                 pass

--- a/goth/runner/probe/__init__.py
+++ b/goth/runner/probe/__init__.py
@@ -220,7 +220,7 @@ class Probe(abc.ABC):
         self._logger.info("Waiting for yagna REST API to be listening")
         if self.container.logs:
             await self.container.logs.wait_for_entry(
-                "Starting .* service on .*.", timeout=30
+                "Starting .*actix-web-service.* service on .*.", timeout=30
             )
 
         # Obtain the IP address of the container


### PR DESCRIPTION
Why:
 - Goth now incorrectly assumes regex for REST API which is used also for GSB
 
 What:
 - make this regex more strict
 
 Emerged after https://github.com/golemfactory/yagna/issues/1301