### PR TITLE
Fix fetching latest run in ArtifactDownloader

### DIFF
--- a/goth/runner/download/__init__.py
+++ b/goth/runner/download/__init__.py
@@ -103,8 +103,8 @@ class ArtifactDownloader(GithubDownloader):
         workflow_id = workflow["id"]
         logger.debug("Fetching workflow runs. workflow_id=%s", workflow_id)
 
-        branch_query = lambda run: run["head_branch"] == branch
-        commit_query = lambda run: run["head_sha"].startswith(commit)
+        branch_query = lambda run: run["head_branch"] == branch  # noqa: E731
+        commit_query = lambda run: run["head_sha"].startswith(commit)  # noqa: E731
 
         paged_workflow_runs = paged(
             self.gh_api.actions.list_workflow_runs,


### PR DESCRIPTION
Resolves https://github.com/golemfactory/goth/issues/530

The cause of the above problem was using the wrong condition when querying the GitHub API for workflow runs. Before this change the queries were made with the parameter `status="completed"`, which means _any completed workflow_ (not necessarily a successful one). This condition has now been made more strict by using `conclusion="success"` instead.

I also used this opportunity to enable paging the workflow run query results in all cases (before this was only done when searching for a specific commit SHA).