### PR TITLE
Expand path variable in get_agent_env_vars

### DIFF
--- a/goth/interactive.py
+++ b/goth/interactive.py
@@ -45,7 +45,7 @@ async def start_network(
         for provider in providers:
             await provider.provider_agent.wait_for_log("Subscribed offer")
 
-        requestor_env = requestor.get_agent_env_vars()
+        requestor_env = requestor.get_agent_env_vars(expand_path=False)
         subnet = providers[0].provider_agent.subnet
         requestor_env["YAGNA_SUBNET"] = subnet
 


### PR DESCRIPTION
This fixes a problem introduced in #520 which is currently causing tests which use `Probe.run_command_on_host` (e.g. most `yapapi` tests to fail`.

The issue is that a non-expanded `$PATH` string was being passed as an environment variable when starting a new process (for example: `PATH=/tmp/some_dir:$PATH`). Since python's `subprocess` does not perform any shell substitution on its `env`, the variables were being used as literals.
This resulted in required host binaries (e.g. `docker-compose`, `python`) being unavailable to the newly-spawned process.