### PR TITLE
Enable MITM proxy for requestor probes

### DIFF
--- a/goth/address.py
+++ b/goth/address.py
@@ -95,11 +95,28 @@ YAGNA_REST_URL = DefaultTemplate(
     default={"port": YAGNA_REST_PORT, "protocol": YAGNA_REST_PROTOCOL},
 )
 
-# Range of ports on the host which can be mapped to yagna daemons' REST API port
+# Range of ports on the host to which yagna daemon ports in containers can be mapped.
+# Port $YAGNA_REST_PORT on N-th started yagna container is mapped to port
+# $HOST_REST_PORT_START + (N-1) on the host.
+
 # NOTE: This variable is used in `nginx.conf` file in the proxy container:
 HOST_REST_PORT_START = 6001
 # NOTE: This variable is used in `nginx.conf` file in the proxy container:
 HOST_REST_PORT_END = 6100
+
+# Ports in the range $HOST_REST_PORT_START .. $HOST_REST_PORT_END are also used
+# by the nginx-proxy container. A request made to port $HOST_REST_PORT_START + (N-1)
+# on nginx-proxy container is forwarded to the MITM proxy (that runs on host)
+# which then forwards the request to $YAGNA_REST_PORT on the N-th yagna container.
+
+# To enable access to those nginx-proxy ports from outside of the Docker network
+# on non-Linux systems, we map ports $HOST_REST_PORT_START .. $HOST_REST_PORT_END on
+# the nginx-proxy to ports ($HOST_REST_PORT_START + O) .. ($HOST_REST_PORT_END + O)
+# on the host, where the offset O is the value of the variable HOST_NGINX_PORT_OFFSET
+# defined below.
+# NOTE: this value has to be consistent with a port mapping definition for the
+# `nginx-proxy` container in `docker-compose.yml`.
+HOST_NGINX_PORT_OFFSET = 10000
 
 
 # Port used by the mitmproxy instance

--- a/goth/api_monitor/router_addon.py
+++ b/goth/api_monitor/router_addon.py
@@ -56,7 +56,7 @@ class RouterAddon:
 
             if server_port == YAGNA_REST_PORT:
                 # This should be a request from an agent running in a yagna container
-                # calling that container's deamon. We route this request to that
+                # calling that container's daemon. We route this request to that
                 # container's host-mapped daemon port.
                 req.host = "127.0.0.1"
                 req.port = self._ports[remote_addr][server_port]

--- a/goth/api_monitor/router_addon.py
+++ b/goth/api_monitor/router_addon.py
@@ -55,20 +55,19 @@ class RouterAddon:
             node_name = self._node_names[remote_addr]
 
             if server_port == YAGNA_REST_PORT:
-                # It's a provider agent calling a yagna daemon
-                # Since we assume that the provider agent runs on the same container
-                # as the provider daemon, we route this request to that container's
-                # host-mapped daemon port
+                # This should be a request from an agent running in a yagna container
+                # calling that container's deamon. We route this request to that
+                # container's host-mapped daemon port.
                 req.host = "127.0.0.1"
                 req.port = self._ports[remote_addr][server_port]
                 req.headers[CALLER_HEADER] = f"{node_name}:agent"
                 req.headers[CALLEE_HEADER] = f"{node_name}:daemon"
 
             elif HOST_REST_PORT_START <= server_port <= HOST_REST_PORT_END:
-                # It's a requestor agent calling a yagna daemon.
-                # We use localhost as the address together with the original port,
-                # since each daemon has its API port mapped to a port on the host
-                # chosen from the specified range.
+                # This should be a request from an agent running on the Docker host
+                # calling a yagna daemon in a container. We use localhost as the address
+                # together with the original port, since each daemon has its API port
+                # mapped to a port on the host chosen from the specified range.
                 req.host = "127.0.0.1"
                 req.port = server_port
                 req.headers[CALLER_HEADER] = f"{node_name}:agent"

--- a/goth/configuration.py
+++ b/goth/configuration.py
@@ -82,6 +82,7 @@ class Configuration:
             subnet="goth",
             volumes=volumes,
             payment_id=self._id_pool.get_id(),
+            use_proxy=use_proxy,
             **kwargs,
         )
 

--- a/goth/default-assets/docker/docker-compose.yml
+++ b/goth/default-assets/docker/docker-compose.yml
@@ -13,7 +13,16 @@ services:
         # harness on the host machine
         image: proxy-nginx
         ports:
-            - "16000-16100:6000-6100"
+            # Requests to ports 6001-6100 in proxy-nginx are forwarded
+            # to the MITM proxy started by the test runner, and further
+            # to yagna API port (usually 6000) in yagna containers:
+            # request to port 6001 is forwarded to (yagna API port in)
+            # the first yagna container, request to port 6002 -- to
+            # the second one, and so on.
+            # To make these ports available from Docker host (on some
+            # systems, Docker network may be unreachable from the host)
+            # we map them to ports 16001-16100 on the host.
+            - "16001-16100:6001-6100"
 
     ethereum:
         image: docker.pkg.github.com/golemfactory/gnt2/gnt2-docker-yagna:483c6f241edd

--- a/goth/default-assets/docker/docker-compose.yml
+++ b/goth/default-assets/docker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
         # harness on the host machine
         image: proxy-nginx
         ports:
-            - "6000:6000"
+            - "16000-16100:6000-6100"
 
     ethereum:
         image: docker.pkg.github.com/golemfactory/gnt2/gnt2-docker-yagna:483c6f241edd

--- a/goth/default-assets/goth-config.yml
+++ b/goth/default-assets/goth-config.yml
@@ -52,6 +52,7 @@ nodes:
 
   - name: "requestor"
     type: "Requestor"
+    use-proxy: True
 
   - name: "provider-1"
     type: "VM-Wasm-Provider"

--- a/goth/node.py
+++ b/goth/node.py
@@ -4,6 +4,7 @@ from typing import Dict
 
 from goth.address import (
     ACTIVITY_API_URL,
+    MARKET_API_URL,
     PAYMENT_API_URL,
     ROUTER_HOST,
     ROUTER_PORT,
@@ -45,7 +46,12 @@ def node_environment(
 
     if rest_api_url_base:
         agent_env = {
+            # Setting URLs for all three APIs has the same effect as setting
+            # YAGNA_API_URL to YAGNA_REST_URL.substitute(base=rest_api_url_base).
+            # We set all three separately so it's easier to selectively disable
+            # proxy for certain APIs (if a need to do so arises).
             "YAGNA_ACTIVITY_URL": ACTIVITY_API_URL.substitute(base=rest_api_url_base),
+            "YAGNA_MARKET_URL": MARKET_API_URL.substitute(base=rest_api_url_base),
             "YAGNA_PAYMENT_URL": PAYMENT_API_URL.substitute(base=rest_api_url_base),
         }
         node_env.update(agent_env)

--- a/goth/runner/__init__.py
+++ b/goth/runner/__init__.py
@@ -80,7 +80,7 @@ class Runner:
     """A stack of `AsyncContextManager` instances to be closed on runner shutdown."""
 
     _nginx_container_address: Optional[str]
-    """An IP address of the container running nginx proxy."""
+    """The IP address of the container running nginx proxy."""
 
     _topology: List[YagnaContainerConfig]
     """A list of configuration objects for the containers to be instantiated."""
@@ -256,7 +256,7 @@ class Runner:
                 if "nginx" in name
             ]
             assert len(nginx_containers) == 1, (
-                "Expected to find a single nginx container,"
+                "Expected to find a single nginx proxy container,"
                 f" found {len(nginx_containers)} instead"
             )
             self._nginx_container_address = nginx_containers[0]

--- a/goth/runner/container/compose.py
+++ b/goth/runner/container/compose.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import logging
 import os
 from pathlib import Path
-from typing import ClassVar, Dict, Optional, Tuple
+from typing import AsyncIterator, ClassVar, Dict, Optional
 
 from docker import DockerClient
 import yaml
@@ -95,7 +95,7 @@ class ComposeNetworkManager:
 
     async def start_network(
         self, log_dir: Path, force_build: bool = False
-    ) -> Dict[str, Tuple[str, str]]:
+    ) -> Dict[str, ContainerInfo]:
         """Start the compose network based on this manager's compose file.
 
         This step may include (re)building the network's docker images.
@@ -221,7 +221,7 @@ class ComposeNetworkManager:
 @contextlib.asynccontextmanager
 async def run_compose_network(
     compose_manager: ComposeNetworkManager, log_dir: Path, force_build: bool = False
-) -> Dict[str, ContainerInfo]:
+) -> AsyncIterator[Dict[str, ContainerInfo]]:
     """Implement AsyncContextManager for starting/stopping docker compose network."""
 
     try:

--- a/goth/runner/container/yagna.py
+++ b/goth/runner/container/yagna.py
@@ -38,6 +38,14 @@ class YagnaContainerConfig(DockerContainerConfig):
     payment_id: Optional[payment.PaymentId]
     """Custom key and payment accounts to be imported into yagna ID service."""
 
+    use_proxy: bool
+    """Whether the probe will route REST API calls through MITM proxy.
+
+    This setting is used when initializing the `api` component of the probe
+    instantiated from this config, as well as to define the environment in which
+    commands run by `Probe.run_command_on_host()` are run.
+    """
+
     def __init__(
         self,
         name: str,
@@ -47,6 +55,7 @@ class YagnaContainerConfig(DockerContainerConfig):
         environment: Optional[Dict[str, str]] = None,
         privileged_mode: bool = False,
         payment_id: Optional[payment.PaymentId] = None,
+        use_proxy: bool = False,
         **probe_properties,
     ):
         super().__init__(name, volumes or {}, log_config, privileged_mode)
@@ -54,6 +63,7 @@ class YagnaContainerConfig(DockerContainerConfig):
         self.probe_properties = probe_properties or {}
         self.environment = environment or {}
         self.payment_id = payment_id
+        self.use_proxy = use_proxy
 
 
 class YagnaContainer(DockerContainer):

--- a/goth/runner/probe/__init__.py
+++ b/goth/runner/probe/__init__.py
@@ -13,6 +13,7 @@ from typing import (
     Dict,
     Iterator,
     List,
+    Mapping,
     Optional,
     Tuple,
     TYPE_CHECKING,
@@ -340,7 +341,7 @@ class Probe(abc.ABC):
     async def run_command_on_host(
         self,
         command: str,
-        env: Optional[Dict[str, str]] = None,
+        env: Optional[Mapping[str, str]] = None,
         command_timeout: float = 300,
     ) -> AsyncIterator[Tuple[asyncio.Task, PatternMatchingEventMonitor]]:
         """Run `command` on host in given `env` and with optional `timeout`.
@@ -361,7 +362,9 @@ class Probe(abc.ABC):
         cmd_env = {**env} if env is not None else {}
         cmd_env.update(self.get_agent_env_vars())
 
-        cmd_monitor = PatternMatchingEventMonitor(name="command output")
+        cmd_monitor: PatternMatchingEventMonitor = PatternMatchingEventMonitor(
+            name="command output"
+        )
         cmd_monitor.start()
 
         try:

--- a/goth/runner/probe/__init__.py
+++ b/goth/runner/probe/__init__.py
@@ -236,8 +236,6 @@ class Probe(abc.ABC):
         self.ip_address = get_container_address(
             self._docker_client, self.container.name
         )
-        self._logger.info("IP address: %s", self.ip_address)
-
         nginx_ip_address = self.runner.nginx_container_address
         self._logger.info(
             "Yagna API host:port in Docker network: "

--- a/goth/runner/probe/rest_client.py
+++ b/goth/runner/probe/rest_client.py
@@ -14,8 +14,6 @@ from goth.address import (
     ACTIVITY_API_URL,
     MARKET_API_URL,
     PAYMENT_API_URL,
-    YAGNA_REST_PORT,
-    YAGNA_REST_URL,
 )
 from goth.runner.probe.component import ProbeComponent
 
@@ -80,13 +78,7 @@ class RestApiComponent(ProbeComponent):
 
     def __init__(self, probe: "Probe"):
         super().__init__(probe)
-
-        # We reach the daemon through MITM proxy running on localhost using the
-        # container's unique port mapping
-        host_port = probe.container.ports[YAGNA_REST_PORT]
-        proxy_ip = "127.0.0.1"
-        base_hostname = YAGNA_REST_URL.substitute(host=proxy_ip, port=host_port)
-
+        base_hostname = probe.get_yagna_api_url()
         self._init_activity_api(base_hostname)
         self._init_payment_api(base_hostname)
         self._init_market_api(base_hostname)

--- a/test/unit/runner/container/test_utils.py
+++ b/test/unit/runner/container/test_utils.py
@@ -20,7 +20,10 @@ def mock_container():
     mock_container.attrs = {
         "NetworkSettings": {
             "Networks": {
-                DockerContainer.DEFAULT_NETWORK: {"IPAddress": TEST_IP_ADDRESS}
+                DockerContainer.DEFAULT_NETWORK: {
+                    "IPAddress": TEST_IP_ADDRESS,
+                    "Aliases": [],
+                }
             }
         }
     }

--- a/test/unit/runner/probe/test_probe.py
+++ b/test/unit/runner/probe/test_probe.py
@@ -2,7 +2,7 @@
 import pytest
 from unittest.mock import MagicMock
 
-from goth.address import YAGNA_REST_PORT, YAGNA_REST_URL
+from goth.address import YAGNA_REST_PORT, YAGNA_REST_URL, HOST_NGINX_PORT_OFFSET
 import goth.runner.container.yagna
 from goth.runner.probe import Probe
 
@@ -14,18 +14,24 @@ async def test_get_yagna_api_url(monkeypatch, use_proxy: bool):
 
     monkeypatch.setattr(goth.runner.probe, "YagnaContainer", MagicMock)
 
+    host_mapped_port = 6789
+    host_mapped_nginx_port = HOST_NGINX_PORT_OFFSET + host_mapped_port
+
     probe = Probe(
         runner=MagicMock(),
         client=MagicMock(),
         config=MagicMock(use_proxy=use_proxy),
         log_config=MagicMock(),
     )
-    probe.ip_address = "1.2.3.4"
-    probe.container.ports = {YAGNA_REST_PORT: "6789"}
+    probe.container.ports = {YAGNA_REST_PORT: host_mapped_port}
 
     if use_proxy:
-        expected_url = YAGNA_REST_URL.substitute(host="127.0.0.1", port="6789")
+        expected_url = YAGNA_REST_URL.substitute(
+            host="127.0.0.1", port=host_mapped_nginx_port
+        )
     else:
-        expected_url = YAGNA_REST_URL.substitute(host=probe.ip_address)
+        expected_url = YAGNA_REST_URL.substitute(
+            host="127.0.0.1", port=host_mapped_port
+        )
 
     assert probe.get_yagna_api_url() == expected_url

--- a/test/unit/runner/probe/test_probe.py
+++ b/test/unit/runner/probe/test_probe.py
@@ -1,0 +1,31 @@
+"""Unit tests for the goth.runner.probe.Probe class."""
+import pytest
+from unittest.mock import MagicMock
+
+from goth.address import YAGNA_REST_PORT, YAGNA_REST_URL
+import goth.runner.container.yagna
+from goth.runner.probe import Probe
+
+
+@pytest.mark.parametrize("use_proxy", [False, True])
+@pytest.mark.asyncio
+async def test_get_yagna_api_url(monkeypatch, use_proxy: bool):
+    """Test if get_yagna_api_url() returns correct URL for given use_proxy setting."""
+
+    monkeypatch.setattr(goth.runner.probe, "YagnaContainer", MagicMock)
+
+    probe = Probe(
+        runner=MagicMock(),
+        client=MagicMock(),
+        config=MagicMock(use_proxy=use_proxy),
+        log_config=MagicMock(),
+    )
+    probe.ip_address = "1.2.3.4"
+    probe.container.ports = {YAGNA_REST_PORT: "6789"}
+
+    if use_proxy:
+        expected_url = YAGNA_REST_URL.substitute(host="127.0.0.1", port="6789")
+    else:
+        expected_url = YAGNA_REST_URL.substitute(host=probe.ip_address)
+
+    assert probe.get_yagna_api_url() == expected_url

--- a/test/unit/runner/probe/test_run_command_on_host.py
+++ b/test/unit/runner/probe/test_run_command_on_host.py
@@ -14,7 +14,7 @@ async def test_run_command_on_host(monkeypatch):
 
     runner = MagicMock()
     docker_client = MagicMock()
-    container_config = MagicMock()
+    container_config = MagicMock(use_proxy=False)
     log_config = MagicMock()
 
     monkeypatch.setattr(goth.runner.probe, "YagnaContainer", MagicMock(spec="ports"))


### PR DESCRIPTION
Resolves #429 

This was meant to be a small PR that adds `use_proxy = True` to the specification of the requestor node in the default goth config file and checks that the communication between the requestor agent (running on Docker host) and the requestor daemon passes through the MITM proxy.

Changes:
1. Ports 6000-6100 on `proxy-nginx` are mapped to ports 16000-16100 on the host. This is to make ports 6000-6100 on `proxy-nginx` reachable via localhost (`127.0.0.1`) and is important for some non-Linux systems, where the Docker compose network is not reachable directly. On such a system, an agent running on Docker host may reach the  daemon by sending a request to an address such as `127.0.0.1:16001`. Such request is then forwarded to `proxy-nginx:6001` in the Docker network (according to port mapping defined in `docker-compose.yml`) and then to the MITM proxy (by `nginx`).

2. `ComposeNetworkManager.start_network()` and `run_compose_network()` context manager return a dictionary with information on the containers started by Docker compose. This information is stored by the Runner and is used to determine the address of the `proxy-nginx` container. **This is not really needed, since thanks to port mapping defined in 1., ports on `proxy-nginx` assigned to specific daemons are mapped to ports on the Docker host.**

3. Using proxy is turned on for Market API. For some reason, it was turned off, even if calls to Activity API and to Payment API were made through proxy.