### PR TITLE
MITM proxy integration test

### DIFF
--- a/test/integration/test_use_proxy.py
+++ b/test/integration/test_use_proxy.py
@@ -1,0 +1,80 @@
+"""Integration test for agent-daemon communication through MITM proxy."""
+import asyncio
+from functools import partial
+from pathlib import Path
+
+import pytest
+
+
+from goth.configuration import load_yaml
+from goth.runner import Runner
+from goth.runner.probe import RequestorProbe
+
+from goth.assertions import EventStream
+from goth.api_monitor.api_events import APIEvent, APIRequest
+
+
+async def api_call_made(container_name: str, stream: EventStream[APIEvent]) -> bool:
+    """Assert that an API call to `container_name` has been made in the past."""
+
+    for event in stream.past_events:
+        if isinstance(event, APIRequest) and event.callee == f"{container_name}:daemon":
+            return True
+    raise AssertionError(f"No API call to {container_name} registered by proxy")
+
+
+async def no_api_call_made(container_name: str, stream: EventStream[APIEvent]) -> bool:
+    """Assert that no API call to `container_name` has been made in the past."""
+
+    try:
+        await api_call_made(container_name, stream)
+    except AssertionError:
+        return True
+    raise AssertionError(f"API call to {container_name} registered by proxy")
+
+
+@pytest.mark.asyncio
+async def test_use_proxy(default_goth_config: Path, log_dir: Path) -> None:
+    """Test if runner correctly sets up agent-deamon communication through proxy."""
+
+    overrides = [
+        (
+            "nodes",
+            [
+                {"name": "requestor", "type": "Requestor", "use-proxy": True},
+                {"name": "provider-1", "type": "VM-Wasm-Provider", "use-proxy": True},
+                {"name": "provider-2", "type": "VM-Wasm-Provider", "use-proxy": False},
+            ],
+        )
+    ]
+    goth_config = load_yaml(default_goth_config, overrides)
+
+    runner = Runner(
+        base_log_dir=log_dir,
+        compose_config=goth_config.compose_config,
+    )
+
+    async with runner(goth_config.containers):
+
+        for probe in runner.probes:
+            if isinstance(probe, RequestorProbe):
+                await probe.api.payment.get_requestor_accounts()
+
+        # Make sure provider agents make some API calls
+        await asyncio.sleep(10)
+
+        for probe in runner.probes:
+            if probe.uses_proxy:
+                assertion = runner.proxy.monitor.add_assertion(
+                    partial(api_call_made, probe.container.name),
+                    name=f"api_call_made({probe.container.name})",
+                )
+                assert await assertion.wait_for_result()
+
+        for probe in runner.probes:
+            if not probe.uses_proxy:
+                assertion = runner.proxy.monitor.add_assertion(
+                    partial(no_api_call_made, probe.container.name),
+                    name=f"no_api_call_made({probe.container.name})",
+                )
+                assert await assertion.wait_for_result()


### PR DESCRIPTION
**Note: this PR is superseded by #538. No need to merge it separately.**

This PR adds an integration tests that starts the usual two provider nodes and a single requestor node and sets up agent/daemon communication so that one of the providers and the requestor use MITM proxy, and the other provider does not.

Assertions on API events are then used to check that the traffic between local (in-runner) requestor agent and the requestor daemon, as well as between one provider agent and its daemon, is captured by the MITM proxy, and the traffic between the other provider agent and its daemon is not (as specified in test configuration).