### PR TITLE
Make waiting for API events in tests more convenient

### DIFF
--- a/goth/api_monitor/__init__.py
+++ b/goth/api_monitor/__init__.py
@@ -1,1 +1,3 @@
-"""Empty file to keep python modules happy."""
+"""EventMonitor for API events and MITM proxy add-ons for attaching the monitor."""
+
+from .api_events import APIEvent, APIRequest, APIResponse, APIError  # noqa F401

--- a/goth/runner/log.py
+++ b/goth/runner/log.py
@@ -82,10 +82,6 @@ LOGGING_CONFIG = {
             "propagate": False,
         },
         "transitions": {"level": "WARNING"},
-        "root": {
-            "handlers": ["console", "runner_file"],
-            "level": "INFO",
-        },
     },
 }
 

--- a/goth/runner/log.py
+++ b/goth/runner/log.py
@@ -67,14 +67,14 @@ LOGGING_CONFIG = {
         "goth.api_monitor": {
             "handlers": [],
             "propagate": False,
-            # Setting this to "DEBUG" can help in diagnosing issues with routing
-            # in the proxy. Use "INFO" to avoid verbose logging of requests/responses.
             "level": "DEBUG",
         },
-        "test.yagna": {
-            "handlers": ["console", "runner_file"],
+        "goth.api_monitor.router_addon": {
+            "handlers": [],
             "propagate": False,
-            "level": "DEBUG",
+            # Setting this to "DEBUG" can help in diagnosing issues with routing
+            # in the proxy. Use "INFO" to avoid verbose logging of requests/responses.
+            "level": "INFO",
         },
         "aiohttp": {
             "handlers": ["console", "runner_file"],
@@ -82,6 +82,10 @@ LOGGING_CONFIG = {
             "propagate": False,
         },
         "transitions": {"level": "WARNING"},
+        "root": {
+            "handlers": ["console", "runner_file"],
+            "level": "INFO",
+        },
     },
 }
 

--- a/goth/runner/log_monitor.py
+++ b/goth/runner/log_monitor.py
@@ -134,8 +134,10 @@ class PatternMatchingEventMonitor(EventMonitor[E]):
 
         regex = re.compile(pattern)
         try:
-            event = await self.wait_for_event(
-                lambda e: regex.match(self.event_str(e)) is not None, timeout
+            event, _match = await self.wait_for_event(
+                lambda e: regex.match(self.event_str(e)),
+                name=pattern,
+                timeout=timeout,
             )
             return event
         except asyncio.TimeoutError:

--- a/goth/runner/proxy.py
+++ b/goth/runner/proxy.py
@@ -109,7 +109,7 @@ class Proxy:
 
 
 @contextlib.asynccontextmanager
-async def run_proxy(proxy: Proxy) -> AsyncIterator[Proxy]:
+async def run_proxy(proxy: Proxy) -> AsyncIterator[None]:
     """Implement AsyncContextManager protocol for starting and stopping a Proxy."""
 
     try:

--- a/test/integration/test_interactive.py
+++ b/test/integration/test_interactive.py
@@ -10,7 +10,7 @@ from goth.interactive import start_network, env_file
 
 @pytest.mark.asyncio
 async def test_interactive(
-    capsys: pytest.CaptureFixture, default_goth_config: Path, log_dir: Path
+    default_goth_config: Path, log_dir: Path, capsys: pytest.CaptureFixture
 ) -> None:
     """Test if goth interactive mode launches correctly."""
     goth_config = load_yaml(default_goth_config, [])

--- a/test/integration/test_use_proxy.py
+++ b/test/integration/test_use_proxy.py
@@ -18,7 +18,7 @@ async def api_call_made(container_name: str, stream: EventStream[APIEvent]) -> b
     """Assert that an API call to `container_name` is made."""
 
     async for event in stream:
-        if isinstance(event, APIRequest) and event.callee == f"{container_name}:daemon":
+        if isinstance(event, APIRequest) and event.node_name == container_name:
             return True
     raise AssertionError(f"No API call to {container_name} registered by proxy")
 

--- a/test/unit/api_monitor/test_api_events.py
+++ b/test/unit/api_monitor/test_api_events.py
@@ -1,0 +1,192 @@
+"""Unit tests for goth.api_monitor.api_events module."""
+# A large number of flake8 F405 errors due to `import *`
+# flake8: noqa
+import pytest
+
+from goth.api_monitor.api_events import *
+
+
+@pytest.mark.parametrize(
+    "predicate, method, path, params",
+    [
+        # ApproveAgreement
+        (
+            is_approve_agreement,
+            "POST",
+            "market-api/v1/agreements/{agr_id}/approve",
+            {"agr_id": "123-456"},
+        ),
+        (
+            is_approve_agreement,
+            "POST",
+            "market-api/v1/agreements/{agr_id}/approve?param=1",
+            {"agr_id": "123-456"},
+        ),
+        (
+            is_approve_agreement,
+            "POST",
+            "market-api/v1/agreement/{agr_id}/approve",
+            False,
+        ),
+        (
+            is_approve_agreement,
+            "POST",
+            "market-api/v1/agreements/approve",
+            False,
+        ),
+        (
+            is_approve_agreement,
+            "POST",
+            "market_api/v1/agreements/{agr_id}/approve",
+            False,
+        ),
+        # CollectDemands
+        (
+            is_collect_demands,
+            "GET",
+            "market-api/v1/offers/{sub_id}/events",
+            {"sub_id": "123-456"},
+        ),
+        (
+            is_collect_demands,
+            "GET",
+            "market-api/v1/offers/{sub_id}/events?param=1",
+            {"sub_id": "123-456"},
+        ),
+        (is_collect_demands, "GET", "market-api/v1/offers/{sub_id}/event", False),
+        # CounterProposalOffer
+        (
+            is_counter_proposal_offer,
+            "POST",
+            "market-api/v1/offers/{sub_id}/proposals/{prop_id}",
+            {"sub_id": "sub-123", "prop_id": "prop-456"},
+        ),
+        (
+            is_counter_proposal_offer,
+            "POST",
+            "market-api/v1/offers/{sub_id}/proposals/{prop_id}?param=1",
+            {"sub_id": "sub-123", "prop_id": "prop-456"},
+        ),
+        (
+            is_counter_proposal_offer,
+            "POST",
+            "market-api/v1/offers/{sub_id}/proposal/{prop_id}",
+            False,
+        ),
+        (
+            is_counter_proposal_offer,
+            "POST",
+            "market-api/v1/offers/{sub_id}/proposals",
+            False,
+        ),
+        # CreateAgreement
+        (is_create_agreement, "POST", "market-api/v1/agreements", {}),
+        (is_create_agreement, "POST", "market-api/v1/agreements?param=1", {}),
+        (
+            is_create_agreement,
+            "POST",
+            "market-api/v1/agreement",
+            False,
+        ),
+        # SubscribeOffer
+        (is_subscribe_offer, "POST", "market-api/v1/offers", {}),
+        (is_subscribe_offer, "POST", "market-api/v1/offers?param=1", {}),
+        (is_subscribe_offer, "POST", "market-api/v1/offer", False),
+        # UnsubscribeOffer
+        (
+            is_unsubscribe_offer,
+            "DELETE",
+            "market-api/v1/offers/{sub_id}",
+            {"sub_id": "123-456"},
+        ),
+        (
+            is_unsubscribe_offer,
+            "DELETE",
+            "market-api/v1/offers/{sub_id}?param=1",
+            {"sub_id": "123-456"},
+        ),
+        (is_unsubscribe_offer, "DELETE", "market-api/v1/offer/{sub_id}", False),
+        # Paymenr: GetInvoiceEvents
+        (
+            is_get_invoice_events,
+            "GET",
+            "payment-api/v1/invoiceEvents",
+            {},
+        ),
+        (is_get_invoice_events, "GET", "payment-api/v1/invoiceEvents?param=1", {}),
+        # Payment: SendInvoice
+        (
+            is_send_invoice,
+            "POST",
+            "payment-api/v1/invoices/{inv_id}/send",
+            {"inv_id": "123-456"},
+        ),
+        (
+            is_send_invoice,
+            "POST",
+            "payment-api/v1/invoices/{inv_id}/send?param=1",
+            {"inv_id": "123-456"},
+        ),
+        (is_send_invoice, "POST", "payment-api/v1/invoice/{inv_id}/send", False),
+        (is_send_invoice, "POST", "payment-api/v1/invoices/{inv_id}", False),
+    ],
+)
+def test_event_predicates(predicate, method, path, params):
+
+    if params:
+        path = path.format(**params)
+
+    http_req = HTTPRequest.make(
+        method=method,
+        url=f"http://11.22.33.44:5555/{path}",
+        content="mock content",
+        headers={},
+    )
+    http_resp = HTTPResponse.make(status_code=200, content="mock content", headers={})
+
+    req = APIRequest(1, http_req)
+    resp = APIResponse(req, http_resp)
+
+    if params is False:
+        # Test non-matching
+        result = predicate(req, event_type=APIRequest)
+        assert not result
+        result = predicate(resp, event_type=APIResponse)
+        assert not result
+        return
+
+    # Test with predicate called with expected params
+    assert predicate(req, event_type=APIRequest, **params) == (params or True)
+
+    # Test with predicate called without params specified
+    assert predicate(req, event_type=APIRequest) == (params or True)
+
+    # Test with predicate called with non-matching params
+    different_params = {key: value * 2 for key, value in params.items()}
+    if params:
+        assert not predicate(req, event_type=APIRequest, **different_params)
+
+    # Repeat tests with predicate called for a response
+    assert predicate(resp, event_type=APIResponse, **params) == (params or True)
+    assert predicate(resp, event_type=APIResponse) == (params or True)
+    if params:
+        assert not predicate(resp, event_type=APIResponse, **different_params)
+
+    # Test with non-matching type
+    assert not predicate(req, event_type=APIResponse, **params)
+    assert not predicate(resp, event_type=APIRequest, **params)
+
+    # Test with different method
+    different_method = "GET" if method == "POST" else "POST"
+    http_req = HTTPRequest.make(
+        method=different_method,
+        url=f"http://11.22.33.44:5555/{path}",
+        content="mock content",
+        headers={},
+    )
+    http_resp = HTTPResponse.make(status_code=200, content="mock content", headers={})
+    req = APIRequest(1, http_req)
+    resp = APIResponse(req, http_resp)
+
+    assert not predicate(req, event_type=APIRequest)
+    assert not predicate(resp, event_type=APIResponse)

--- a/test/unit/assertions/test_monitor.py
+++ b/test/unit/assertions/test_monitor.py
@@ -147,9 +147,9 @@ async def test_waitable_monitor():
     events = []
 
     async def wait_for_events():
-        events.append(await monitor.wait_for_event(lambda e: e == 1))
-        events.append(await monitor.wait_for_event(lambda e: e == 2))
-        events.append(await monitor.wait_for_event(lambda e: e == 3))
+        events.append((await monitor.wait_for_event(lambda e: e == 1))[0])
+        events.append((await monitor.wait_for_event(lambda e: e == 2))[0])
+        events.append((await monitor.wait_for_event(lambda e: e == 3))[0])
 
     await monitor.add_event(0)
     await monitor.add_event(1)


### PR DESCRIPTION
The purpose of this PR is to facilitate writing test scenarios with steps that wait for particular API events in addition to (or instead of) waiting for particular log entries.

Main changes:

* The method `Runner.wait_for_api_event(predicate, ...)` is added. It can be used to wait until an API event satisfying given predicate is registered by MITM proxy, much like the existing method `Probe.wait_for_log(predicate, ...)` is used to wait until a log entry satisfying given predicate occurs in the agent log stream for a particular probe. Unlike in case of log monitors examined by `Probe.wait_for_log()`, the method `Runner.wait_for_api_event()` processes API events from all nodes, treated as a single stream of events. 

* The method `EventMonitor.wait_for_event()`, used internally by both `Runner.wait_for_api_event()` and `Probe.wait_for_log()`, is modified to accept a more general predicate that can accept arbitrary positional and keyword arguments, along with the event. The predicate can also return an arbitrary type: conversion to `bool` is used to determine if the predicate accepts given event. Value returned by the predicate for the accepted event is returned along with the event from `EventMonitor.wait_for_event()`.

* Some predicates for API events are added to `goth.api_monitor.api_event` module. 