### PR TITLE
Reduce timeout for collect_offers from 5 -> 1

### DIFF
--- a/goth/runner/probe/mixin.py
+++ b/goth/runner/probe/mixin.py
@@ -75,7 +75,7 @@ class ActivityApiMixin:
 
         while len(results) < num_results:
             results = await self.api.activity.control.get_exec_batch_results(
-                activity_id, batch_id
+                activity_id, batch_id, timeout=1
             )
             await asyncio.sleep(1.0)
         return results


### PR DESCRIPTION
Found during investigation of last nights nightly release branch build:
https://github.com/golemfactory/yagna/actions/runs/1318773233

Related yagna PR: https://github.com/golemfactory/yagna/pull/1639

Passed the test:
https://github.com/golemfactory/yagna/runs/3837633048?check_suite_focus=true