### PR TITLE
per-container payment config

### DIFF
--- a/goth/configuration.py
+++ b/goth/configuration.py
@@ -18,7 +18,7 @@ from goth.payment_config import get_payment_config, PaymentConfig
 
 DEFAULT_PAYMENT_CONFIG_NAME = "zksync"
 """Determines PaymentConfig object that will be used for containers
-without specified "payment_config" """
+without specified "payment-config" """
 
 Override = Tuple[str, Any]
 """Type representing a single value override in a YAML config file.
@@ -301,7 +301,7 @@ def load_yaml(
             use_proxy = node.get("use-proxy", False)
 
             payment_config_name = node.get(
-                "payment_config", DEFAULT_PAYMENT_CONFIG_NAME
+                "payment-config", DEFAULT_PAYMENT_CONFIG_NAME
             )
             payment_config = get_payment_config(payment_config_name)
 

--- a/goth/configuration.py
+++ b/goth/configuration.py
@@ -84,7 +84,7 @@ class Configuration:
             privileged_mode=privileged_mode,
             subnet="goth",
             volumes=volumes,
-            payment_id=self._id_pool.get_id(),
+            payment_id=self._id_pool.get_id(payment_config),
             use_proxy=use_proxy,
             **kwargs,
         )

--- a/goth/configuration.py
+++ b/goth/configuration.py
@@ -17,7 +17,8 @@ from goth.runner.probe import Probe, YagnaContainerConfig
 from goth.payment_config import get_payment_config, PaymentConfig
 
 DEFAULT_PAYMENT_CONFIG_NAME = "zksync"
-"""This PaymentConfig will be used for containers that have no specified "payments" """
+"""Determines PaymentConfig object that will be used for containers
+without specified "payment_config" """
 
 Override = Tuple[str, Any]
 """Type representing a single value override in a YAML config file.
@@ -299,7 +300,9 @@ def load_yaml(
             type_name = node["type"]
             use_proxy = node.get("use-proxy", False)
 
-            payment_config_name = node.get("payments", DEFAULT_PAYMENT_CONFIG_NAME)
+            payment_config_name = node.get(
+                "payment_config", DEFAULT_PAYMENT_CONFIG_NAME
+            )
             payment_config = get_payment_config(payment_config_name)
 
             class_, volumes, privileged_mode, env_dict = node_types[type_name]

--- a/goth/configuration.py
+++ b/goth/configuration.py
@@ -16,6 +16,7 @@ from goth.node import node_environment
 from goth.runner.probe import Probe, YagnaContainerConfig
 from goth.payment_config import get_payment_config, PaymentConfig
 
+DEFAULT_PAYMENT_DRIVER = "zksync"
 
 Override = Tuple[str, Any]
 """Type representing a single value override in a YAML config file.
@@ -80,6 +81,7 @@ class Configuration:
         container_cfg = YagnaContainerConfig(
             name=name,
             probe_type=type,
+            payment_config=payment_config,
             environment=node_env,
             privileged_mode=privileged_mode,
             subnet="goth",
@@ -296,7 +298,7 @@ def load_yaml(
             type_name = node["type"]
             use_proxy = node.get("use-proxy", False)
 
-            payment_config_name = node.get("payments", "zksync")
+            payment_config_name = node.get("payments", DEFAULT_PAYMENT_DRIVER)
             payment_config = get_payment_config(payment_config_name)
 
             class_, volumes, privileged_mode, env_dict = node_types[type_name]

--- a/goth/configuration.py
+++ b/goth/configuration.py
@@ -59,6 +59,7 @@ class Configuration:
         name: str,
         use_proxy: bool,
         privileged_mode: bool,
+        payments: str,
         environment: Optional[Dict[str, str]] = None,
         volumes: Optional[Dict[Path, Path]] = None,
         **kwargs,
@@ -67,10 +68,11 @@ class Configuration:
 
         if use_proxy:
             node_env = node_environment(
+                payments,
                 rest_api_url_base=YAGNA_REST_URL.substitute(host=PROXY_HOST)
             )
         else:
-            node_env = node_environment()
+            node_env = node_environment(payments)
         if environment:
             node_env.update(environment)
 
@@ -292,6 +294,7 @@ def load_yaml(
             name = node["name"]
             type_name = node["type"]
             use_proxy = node.get("use-proxy", False)
+            payments = node.get("payments", "zksync")
             class_, volumes, privileged_mode, env_dict = node_types[type_name]
             config.add_node(
                 class_,
@@ -300,6 +303,7 @@ def load_yaml(
                 privileged_mode=privileged_mode,
                 environment=env_dict,
                 volumes=volumes,
+                payments=payments,
             )
 
     return config

--- a/goth/configuration.py
+++ b/goth/configuration.py
@@ -16,7 +16,8 @@ from goth.node import node_environment
 from goth.runner.probe import Probe, YagnaContainerConfig
 from goth.payment_config import get_payment_config, PaymentConfig
 
-DEFAULT_PAYMENT_DRIVER = "zksync"
+DEFAULT_PAYMENT_CONFIG_NAME = "zksync"
+"""This PaymentConfig will be used for containers that have no specified "payments" """
 
 Override = Tuple[str, Any]
 """Type representing a single value override in a YAML config file.
@@ -298,7 +299,7 @@ def load_yaml(
             type_name = node["type"]
             use_proxy = node.get("use-proxy", False)
 
-            payment_config_name = node.get("payments", DEFAULT_PAYMENT_DRIVER)
+            payment_config_name = node.get("payments", DEFAULT_PAYMENT_CONFIG_NAME)
             payment_config = get_payment_config(payment_config_name)
 
             class_, volumes, privileged_mode, env_dict = node_types[type_name]

--- a/goth/node.py
+++ b/goth/node.py
@@ -32,9 +32,10 @@ def payments_env(payments: str) -> Dict[str, str]:
             "MAINNET_GLM_CONTRACT_ADDRESS": contract_address,
         },
         'zksync': {
-            "YA_PAYMENT_NETWORK": "mainnet",
-            "ZKSYNC_MAINNET_RPC_ADDRESS": "http://zksync:3030",
+            #   TODO: For some reason, "rinkeby" works and "mainnet" doesn't. Why?
+            "YA_PAYMENT_NETWORK": "rinkeby",
             "ZKSYNC_FAUCET_ADDR": "http://zksync:3030/zk/donatex",
+            "ZKSYNC_RINKEBY_RPC_ADDRESS": "http://zksync:3030",
         },
     }
     return payments_env[payments]

--- a/goth/node.py
+++ b/goth/node.py
@@ -15,30 +15,47 @@ from goth.address import (
 DEFAULT_SUBNET = "goth"
 
 
+def payments_env(payments: str) -> Dict[str, str]:
+    """Payment-related part of the environment."""
+
+    contract_address = "0xFDFEF9D10d929cB3905C71400ce6be1990EA0F34"
+    ethereum_container_url = "http://ethereum:8545"
+    payments_env = {
+        'polygon': {
+            "YA_PAYMENT_NETWORK": "polygon",
+            "POLYGON_GETH_ADDR": ethereum_container_url,
+            "POLYGON_GLM_CONTRACT_ADDRESS": contract_address,
+        },
+        'mainnet': {
+            "YA_PAYMENT_NETWORK": "mainnet",
+            "MAINNET_GETH_ADDR": ethereum_container_url,
+            "MAINNET_GLM_CONTRACT_ADDRESS": contract_address,
+        },
+        'zksync': {
+            "YA_PAYMENT_NETWORK": "mainnet",
+            "ZKSYNC_MAINNET_RPC_ADDRESS": "http://zksync:3030",
+            "ZKSYNC_FAUCET_ADDR": "http://zksync:3030/zk/donatex",
+        },
+    }
+    return payments_env[payments]
+
+
 def node_environment(
-    rest_api_url_base: str = "", account_list: str = ""
+    payments: str, rest_api_url_base: str = "", account_list: str = ""
 ) -> Dict[str, str]:
     """Construct an environment for executing commands in a yagna docker container."""
 
     daemon_env = {
         "CENTRAL_NET_HOST": f"{ROUTER_HOST}:{ROUTER_PORT}",
         # TODO: Remove after 0.7.x is released, 0.6.x still requires it to be compatible
-        "ERC20_RINKEBY_GETH_ADDR": "http://ethereum:8545",
-        "RINKEBY_GETH_ADDR": "http://ethereum:8545",
         "GSB_URL": YAGNA_BUS_URL.substitute(host="0.0.0.0"),
         "IDLE_AGREEMENT_TIMEOUT": "600s",
         "MEAN_CYCLIC_BCAST_INTERVAL": "5s",
         "MEAN_CYCLIC_UNSUBSCRIBES_INTERVAL": "5s",
         "REQUIRED_CONFIRMATIONS": "1",
-        "RINKEBY_TGLM_CONTRACT_ADDRESS": "0xFDFEF9D10d929cB3905C71400ce6be1990EA0F34",
         "RUST_BACKTRACE": "1",
         "RUST_LOG": "debug,tokio_core=info,tokio_reactor=info,hyper=info",
-        "YA_PAYMENT_NETWORK": "rinkeby",
         "YAGNA_API_URL": YAGNA_REST_URL.substitute(host="0.0.0.0"),
-        "ZKSYNC_FAUCET_ADDR": "http://zksync:3030/zk/donatex",
-        "ZKSYNC_RINKEBY_RPC_ADDRESS": "http://zksync:3030",
-        # left for compatibility with yagna prior to commit 800efe13
-        "ZKSYNC_RPC_ADDRESS": "http://zksync:3030",
     }
     if account_list:
         daemon_env["ACCOUNT_LIST"] = account_list
@@ -55,5 +72,7 @@ def node_environment(
             "YAGNA_PAYMENT_URL": PAYMENT_API_URL.substitute(base=rest_api_url_base),
         }
         node_env.update(agent_env)
+
+    node_env.update(payments_env(payments))
 
     return node_env

--- a/goth/node.py
+++ b/goth/node.py
@@ -1,6 +1,6 @@
 """Helper class for yagna node environment variables and Volumes."""
 
-from typing import Dict
+from typing import Dict, Optional
 
 from goth.address import (
     ACTIVITY_API_URL,
@@ -15,34 +15,10 @@ from goth.address import (
 DEFAULT_SUBNET = "goth"
 
 
-def payments_env(payments: str) -> Dict[str, str]:
-    """Payment-related part of the environment."""
-
-    contract_address = "0xFDFEF9D10d929cB3905C71400ce6be1990EA0F34"
-    ethereum_container_url = "http://ethereum:8545"
-    payments_env = {
-        'polygon': {
-            "YA_PAYMENT_NETWORK": "polygon",
-            "POLYGON_GETH_ADDR": ethereum_container_url,
-            "POLYGON_GLM_CONTRACT_ADDRESS": contract_address,
-        },
-        'mainnet': {
-            "YA_PAYMENT_NETWORK": "mainnet",
-            "MAINNET_GETH_ADDR": ethereum_container_url,
-            "MAINNET_GLM_CONTRACT_ADDRESS": contract_address,
-        },
-        'zksync': {
-            #   TODO: For some reason, "rinkeby" works and "mainnet" doesn't. Why?
-            "YA_PAYMENT_NETWORK": "rinkeby",
-            "ZKSYNC_FAUCET_ADDR": "http://zksync:3030/zk/donatex",
-            "ZKSYNC_RINKEBY_RPC_ADDRESS": "http://zksync:3030",
-        },
-    }
-    return payments_env[payments]
-
-
 def node_environment(
-    payments: str, rest_api_url_base: str = "", account_list: str = ""
+    rest_api_url_base: str = "",
+    account_list: str = "",
+    payment_env: Optional[Dict[str, str]] = None,
 ) -> Dict[str, str]:
     """Construct an environment for executing commands in a yagna docker container."""
 
@@ -74,6 +50,7 @@ def node_environment(
         }
         node_env.update(agent_env)
 
-    node_env.update(payments_env(payments))
+    if payment_env:
+        node_env.update(payment_env)
 
     return node_env

--- a/goth/node.py
+++ b/goth/node.py
@@ -24,7 +24,6 @@ def node_environment(
 
     daemon_env = {
         "CENTRAL_NET_HOST": f"{ROUTER_HOST}:{ROUTER_PORT}",
-        # TODO: Remove after 0.7.x is released, 0.6.x still requires it to be compatible
         "GSB_URL": YAGNA_BUS_URL.substitute(host="0.0.0.0"),
         "IDLE_AGREEMENT_TIMEOUT": "600s",
         "MEAN_CYCLIC_BCAST_INTERVAL": "5s",

--- a/goth/payment_config.py
+++ b/goth/payment_config.py
@@ -1,32 +1,9 @@
+"""All possible payment-related configuration, in one place."""
 from dataclasses import dataclass
 from typing import Dict
 
-# def payments_env(payments: str) -> Dict[str, str]:
-#     """Payment-related part of the environment."""
-# 
-#     contract_address = "0xFDFEF9D10d929cB3905C71400ce6be1990EA0F34"
-#     ethereum_container_url = "http://ethereum:8545"
-#     payments_env = {
-#         'polygon': {
-#             "YA_PAYMENT_NETWORK": "polygon",
-#             "POLYGON_GETH_ADDR": ethereum_container_url,
-#             "POLYGON_GLM_CONTRACT_ADDRESS": contract_address,
-#         },
-#         'mainnet': {
-#             "YA_PAYMENT_NETWORK": "mainnet",
-#             "MAINNET_GETH_ADDR": ethereum_container_url,
-#             "MAINNET_GLM_CONTRACT_ADDRESS": contract_address,
-#         },
-#         'zksync': {
-#             #   TODO: For some reason, "rinkeby" works and "mainnet" doesn't. Why?
-#             "YA_PAYMENT_NETWORK": "rinkeby",
-#             "ZKSYNC_FAUCET_ADDR": "http://zksync:3030/zk/donatex",
-#             "ZKSYNC_RINKEBY_RPC_ADDRESS": "http://zksync:3030",
-#         },
-#     }
-#     return payments_env[payments]
-
-
+GETH_ADDR = "http://ethereum:8545"
+GLM_CONTRACT_ADDRESS = "0xFDFEF9D10d929cB3905C71400ce6be1990EA0F34"
 
 _payment_config = {
     'zksync': {
@@ -42,28 +19,41 @@ _payment_config = {
     'erc20': {
         'env': {
             "YA_PAYMENT_NETWORK": "mainnet",
-            "MAINNET_GETH_ADDR": "http://ethereum:8545",
-            "MAINNET_GLM_CONTRACT_ADDRESS": "0xFDFEF9D10d929cB3905C71400ce6be1990EA0F34",
+            "MAINNET_GETH_ADDR": GETH_ADDR,
+            "MAINNET_GLM_CONTRACT_ADDRESS": GLM_CONTRACT_ADDRESS,
         },
         'driver': 'erc20',
         'network': 'mainnet',
         'token': 'GLM',
     },
+    'polygon': {
+        'env': {
+            "YA_PAYMENT_NETWORK": "polygon",
+            "MAINNET_GETH_ADDR": GETH_ADDR,
+            "MAINNET_GLM_CONTRACT_ADDRESS": GLM_CONTRACT_ADDRESS,
+        },
+        'driver': 'erc20',
+        'network': 'polygon',
+        'token': 'GLM',
+    }
 }
 
 
 @dataclass
 class PaymentConfig:
+    """All payment-related config for a single container."""
+
     env: Dict[str, str]
     driver: str
     network: str
     token: str
 
 
-def get_payment_config(name: str) -> PaymentConfig:
+def get_payment_config(config_payments_name: str) -> PaymentConfig:
+    """Translate "payments" name from goth-config.yml to a PaymentConfig instance."""
     try:
-        payment_config_kwargs = _payment_config[name]
+        payment_config_kwargs = _payment_config[config_payments_name]
     except KeyError:
-        raise KeyError(f"Unknown payment config name: {name}")
+        raise KeyError(f"Unknown payment config name: {config_payments_name}")
 
     return PaymentConfig(**payment_config_kwargs)

--- a/goth/payment_config.py
+++ b/goth/payment_config.py
@@ -49,11 +49,11 @@ class PaymentConfig:
     token: str
 
 
-def get_payment_config(config_payments_name: str) -> PaymentConfig:
-    """Translate "payments" name from goth-config.yml to a PaymentConfig instance."""
+def get_payment_config(payment_config_name: str) -> PaymentConfig:
+    """Translate "payment_config" from goth-config.yml to a PaymentConfig instance."""
     try:
-        payment_config_kwargs = _payment_config[config_payments_name]
+        payment_config_kwargs = _payment_config[payment_config_name]
     except KeyError:
-        raise KeyError(f"Unknown payment config name: {config_payments_name}")
+        raise KeyError(f"Unknown payment config name: {payment_config_name}")
 
     return PaymentConfig(**payment_config_kwargs)

--- a/goth/payment_config.py
+++ b/goth/payment_config.py
@@ -1,0 +1,59 @@
+from dataclasses import dataclass
+from typing import Dict
+
+# def payments_env(payments: str) -> Dict[str, str]:
+#     """Payment-related part of the environment."""
+# 
+#     contract_address = "0xFDFEF9D10d929cB3905C71400ce6be1990EA0F34"
+#     ethereum_container_url = "http://ethereum:8545"
+#     payments_env = {
+#         'polygon': {
+#             "YA_PAYMENT_NETWORK": "polygon",
+#             "POLYGON_GETH_ADDR": ethereum_container_url,
+#             "POLYGON_GLM_CONTRACT_ADDRESS": contract_address,
+#         },
+#         'mainnet': {
+#             "YA_PAYMENT_NETWORK": "mainnet",
+#             "MAINNET_GETH_ADDR": ethereum_container_url,
+#             "MAINNET_GLM_CONTRACT_ADDRESS": contract_address,
+#         },
+#         'zksync': {
+#             #   TODO: For some reason, "rinkeby" works and "mainnet" doesn't. Why?
+#             "YA_PAYMENT_NETWORK": "rinkeby",
+#             "ZKSYNC_FAUCET_ADDR": "http://zksync:3030/zk/donatex",
+#             "ZKSYNC_RINKEBY_RPC_ADDRESS": "http://zksync:3030",
+#         },
+#     }
+#     return payments_env[payments]
+
+
+
+_payment_config = {
+    'zksync': {
+        'env': {
+            "YA_PAYMENT_NETWORK": "rinkeby",
+            "ZKSYNC_FAUCET_ADDR": "http://zksync:3030/zk/donatex",
+            "ZKSYNC_RINKEBY_RPC_ADDRESS": "http://zksync:3030",
+        },
+        'driver': 'zksync',
+        'network': 'rinkeby',
+        'token': 'tGLM',
+    }
+}
+
+
+@dataclass
+class PaymentConfig:
+    env: Dict[str, str]
+    driver: str
+    network: str
+    token: str
+
+
+def get_payment_config(name: str) -> PaymentConfig:
+    try:
+        payment_config_kwargs = _payment_config[name]
+    except KeyError:
+        raise KeyError(f"Unknown payment config name: {name}")
+
+    return PaymentConfig(**payment_config_kwargs)

--- a/goth/payment_config.py
+++ b/goth/payment_config.py
@@ -50,7 +50,7 @@ class PaymentConfig:
 
 
 def get_payment_config(payment_config_name: str) -> PaymentConfig:
-    """Translate "payment_config" from goth-config.yml to a PaymentConfig instance."""
+    """Translate "payment-config" from goth-config.yml to a PaymentConfig instance."""
     try:
         payment_config_kwargs = _payment_config[payment_config_name]
     except KeyError:

--- a/goth/payment_config.py
+++ b/goth/payment_config.py
@@ -6,36 +6,36 @@ GETH_ADDR = "http://ethereum:8545"
 GLM_CONTRACT_ADDRESS = "0xFDFEF9D10d929cB3905C71400ce6be1990EA0F34"
 
 _payment_config = {
-    'zksync': {
-        'env': {
+    "zksync": {
+        "env": {
             "YA_PAYMENT_NETWORK": "rinkeby",
             "ZKSYNC_FAUCET_ADDR": "http://zksync:3030/zk/donatex",
             "ZKSYNC_RINKEBY_RPC_ADDRESS": "http://zksync:3030",
         },
-        'driver': 'zksync',
-        'network': 'rinkeby',
-        'token': 'tGLM',
+        "driver": "zksync",
+        "network": "rinkeby",
+        "token": "tGLM",
     },
-    'erc20': {
-        'env': {
+    "erc20": {
+        "env": {
             "YA_PAYMENT_NETWORK": "mainnet",
             "MAINNET_GETH_ADDR": GETH_ADDR,
             "MAINNET_GLM_CONTRACT_ADDRESS": GLM_CONTRACT_ADDRESS,
         },
-        'driver': 'erc20',
-        'network': 'mainnet',
-        'token': 'GLM',
+        "driver": "erc20",
+        "network": "mainnet",
+        "token": "GLM",
     },
-    'polygon': {
-        'env': {
+    "polygon": {
+        "env": {
             "YA_PAYMENT_NETWORK": "polygon",
             "POLYGON_GETH_ADDR": GETH_ADDR,
             "POLYGON_GLM_CONTRACT_ADDRESS": GLM_CONTRACT_ADDRESS,
         },
-        'driver': 'erc20',
-        'network': 'polygon',
-        'token': 'GLM',
-    }
+        "driver": "erc20",
+        "network": "polygon",
+        "token": "GLM",
+    },
 }
 
 

--- a/goth/payment_config.py
+++ b/goth/payment_config.py
@@ -38,7 +38,17 @@ _payment_config = {
         'driver': 'zksync',
         'network': 'rinkeby',
         'token': 'tGLM',
-    }
+    },
+    'erc20': {
+        'env': {
+            "YA_PAYMENT_NETWORK": "mainnet",
+            "MAINNET_GETH_ADDR": "http://ethereum:8545",
+            "MAINNET_GLM_CONTRACT_ADDRESS": "0xFDFEF9D10d929cB3905C71400ce6be1990EA0F34",
+        },
+        'driver': 'erc20',
+        'network': 'mainnet',
+        'token': 'GLM',
+    },
 }
 
 

--- a/goth/payment_config.py
+++ b/goth/payment_config.py
@@ -29,8 +29,8 @@ _payment_config = {
     'polygon': {
         'env': {
             "YA_PAYMENT_NETWORK": "polygon",
-            "MAINNET_GETH_ADDR": GETH_ADDR,
-            "MAINNET_GLM_CONTRACT_ADDRESS": GLM_CONTRACT_ADDRESS,
+            "POLYGON_GETH_ADDR": GETH_ADDR,
+            "POLYGON_GLM_CONTRACT_ADDRESS": GLM_CONTRACT_ADDRESS,
         },
         'driver': 'erc20',
         'network': 'polygon',

--- a/goth/runner/cli/yagna_payment_cmd.py
+++ b/goth/runner/cli/yagna_payment_cmd.py
@@ -7,9 +7,6 @@ from goth.runner.cli.base import make_args
 from goth.runner.cli.typing import CommandRunner
 
 
-DEFAULT_PAYMENT_DRIVER = "zksync"
-
-
 @dataclass(frozen=True)
 class Payments:
     """Information about payment amounts."""
@@ -72,7 +69,7 @@ class YagnaPaymentMixin:
     """A mixin class that adds support for `<yagna-cmd> payment` commands."""
 
     def payment_fund(
-        self: CommandRunner, payment_driver: str = DEFAULT_PAYMENT_DRIVER
+        self: CommandRunner, payment_driver: str
     ) -> None:
         """Run `<cmd> payment fund` with optional extra args."""
         args = make_args("payment", "fund", driver=payment_driver)
@@ -80,10 +77,10 @@ class YagnaPaymentMixin:
 
     def payment_init(
         self: CommandRunner,
+        payment_driver: str,
         sender_mode: bool = False,
         receiver_mode: bool = False,
         data_dir: str = "",
-        payment_driver: str = DEFAULT_PAYMENT_DRIVER,
         address: Optional[str] = None,
         network: Optional[str] = None,
     ) -> None:
@@ -109,15 +106,15 @@ class YagnaPaymentMixin:
 
     def payment_status(
         self: CommandRunner,
+        driver: str,
         data_dir: str = "",
-        driver: str = DEFAULT_PAYMENT_DRIVER,
     ) -> PaymentStatus:
         """Run `<cmd> payment status` with optional extra args.
 
         Parse the command's output as a `PaymentStatus` and return it.
         """
 
-        args = make_args("payment", "status", driver.name, data_dir=data_dir)
+        args = make_args("payment", "status", driver, data_dir=data_dir)
         output = self.run_json_command(Dict, *args)
         return PaymentStatus.from_dict(output)
 

--- a/goth/runner/cli/yagna_payment_cmd.py
+++ b/goth/runner/cli/yagna_payment_cmd.py
@@ -68,9 +68,7 @@ class Driver:
 class YagnaPaymentMixin:
     """A mixin class that adds support for `<yagna-cmd> payment` commands."""
 
-    def payment_fund(
-        self: CommandRunner, payment_driver: str
-    ) -> None:
+    def payment_fund(self: CommandRunner, payment_driver: str) -> None:
         """Run `<cmd> payment fund` with optional extra args."""
         args = make_args("payment", "fund", driver=payment_driver)
         self.run_command(*args)

--- a/goth/runner/cli/yagna_payment_cmd.py
+++ b/goth/runner/cli/yagna_payment_cmd.py
@@ -5,10 +5,9 @@ from typing import Dict, Optional
 
 from goth.runner.cli.base import make_args
 from goth.runner.cli.typing import CommandRunner
-from goth.runner.container.payment import PaymentDriver
 
 
-DEFAULT_PAYMENT_DRIVER = PaymentDriver.zksync
+DEFAULT_PAYMENT_DRIVER = "zksync"
 
 
 @dataclass(frozen=True)
@@ -73,10 +72,10 @@ class YagnaPaymentMixin:
     """A mixin class that adds support for `<yagna-cmd> payment` commands."""
 
     def payment_fund(
-        self: CommandRunner, payment_driver: PaymentDriver = DEFAULT_PAYMENT_DRIVER
+        self: CommandRunner, payment_driver: str = DEFAULT_PAYMENT_DRIVER
     ) -> None:
         """Run `<cmd> payment fund` with optional extra args."""
-        args = make_args("payment", "fund", driver=payment_driver.name)
+        args = make_args("payment", "fund", driver=payment_driver)
         self.run_command(*args)
 
     def payment_init(
@@ -84,7 +83,7 @@ class YagnaPaymentMixin:
         sender_mode: bool = False,
         receiver_mode: bool = False,
         data_dir: str = "",
-        payment_driver: PaymentDriver = DEFAULT_PAYMENT_DRIVER,
+        payment_driver: str = DEFAULT_PAYMENT_DRIVER,
         address: Optional[str] = None,
         network: Optional[str] = None,
     ) -> None:
@@ -97,7 +96,7 @@ class YagnaPaymentMixin:
             "payment",
             "init",
             data_dir=data_dir,
-            driver=payment_driver.name,
+            driver=payment_driver,
             address=address,
             network=network,
         )
@@ -111,7 +110,7 @@ class YagnaPaymentMixin:
     def payment_status(
         self: CommandRunner,
         data_dir: str = "",
-        driver: PaymentDriver = DEFAULT_PAYMENT_DRIVER,
+        driver: str = DEFAULT_PAYMENT_DRIVER,
     ) -> PaymentStatus:
         """Run `<cmd> payment status` with optional extra args.
 

--- a/goth/runner/container/payment.py
+++ b/goth/runner/container/payment.py
@@ -123,7 +123,7 @@ class PaymentIdPool:
 
     def get_id(
         self,
-        drivers: Sequence[PaymentDriver] = (PaymentDriver.erc20, PaymentDriver.zksync),
+        drivers: Sequence[PaymentDriver] = (PaymentDriver.zksync,),
         receive: bool = True,
         send: bool = True,
     ) -> PaymentId:

--- a/goth/runner/container/payment.py
+++ b/goth/runner/container/payment.py
@@ -1,15 +1,15 @@
 """Module related to handling payment IDs in yagna containers."""
 
 from dataclasses import asdict, dataclass
-from enum import Enum, unique
 import json
 from pathlib import Path
 import shutil
 from tempfile import gettempdir
-from typing import Iterator, List, Optional, Sequence
+from typing import Iterator, List, Optional
 from uuid import uuid4
 
 from goth.project import DEFAULT_ASSETS_DIR
+from goth.payment_config import PaymentConfig
 
 ENV_ACCOUNT_LIST = "ACCOUNT_LIST"
 
@@ -36,23 +36,14 @@ class KeyPoolDepletedError(Exception):
         super().__init__("No more pre-funded Ethereum keys available.")
 
 
-@unique
-# https://docs.python.org/3/library/enum.html#restricted-enum-subclassing
-class PaymentDriver(str, Enum):
-    """Enum listing the payment drivers that can be used with yagna."""
-
-    erc20 = "erc20"
-    zksync = "zksync"
-
-
 @dataclass
 class Account:
     """Data class representing a single yagna payment account."""
 
     address: str
-    driver: PaymentDriver = PaymentDriver.zksync
-    network: str = "rinkeby"
-    token: str = "tGLM"
+    driver: str
+    network: str
+    token: str
     receive: bool = True
     send: bool = True
 
@@ -123,7 +114,7 @@ class PaymentIdPool:
 
     def get_id(
         self,
-        drivers: Sequence[PaymentDriver] = (PaymentDriver.zksync,),
+        payment_config: PaymentConfig,
         receive: bool = True,
         send: bool = True,
     ) -> PaymentId:
@@ -131,22 +122,21 @@ class PaymentIdPool:
 
         Attempts to obtain a key from the pool and, if available, creates a list of
         payment accounts based on the provided parameters.
-        For each payment driver specified, a separate account is generated.
+        Only a single account is created, for payment_config.driver.
         The parameters `receive` and `send` are shared between the accounts.
         Once the key pool is depleted, attempting to get another account results in
         `KeyPoolDepletedError` being raised.
         """
         key = self._get_key()
-        account_list = [
-            Account(
-                address=f"0x{key.address}",
-                driver=driver,
-                receive=receive,
-                send=send,
-            )
-            for driver in drivers
-        ]
-        return PaymentId(account_list, key)
+        account = Account(
+            address=f"0x{key.address}",
+            driver=payment_config.driver,
+            network=payment_config.network,
+            token=payment_config.token,
+            receive=receive,
+            send=send,
+        )
+        return PaymentId([account], key)
 
     def _get_key(self) -> EthKey:
         try:

--- a/goth/runner/container/yagna.py
+++ b/goth/runner/container/yagna.py
@@ -30,6 +30,9 @@ class YagnaContainerConfig(DockerContainerConfig):
     probe_type: Type["Probe"]
     """Python type of the probe to be instantiated from this config."""
 
+    payment_config: PaymentConfig
+    """Complete payments configuration (driver, network, etc.)."""
+
     probe_properties: Dict[str, Any]
     """Additional properties to be set on the probe object."""
 

--- a/goth/runner/container/yagna.py
+++ b/goth/runner/container/yagna.py
@@ -13,6 +13,7 @@ from goth.runner.container import DockerContainer, DockerContainerConfig
 import goth.runner.container.payment as payment
 import goth.runner.container.utils as utils
 from goth.runner.log import LogConfig
+from goth.payment_config import PaymentConfig
 
 if TYPE_CHECKING:
     from goth.runner.probe import Probe  # noqa: F401
@@ -50,6 +51,7 @@ class YagnaContainerConfig(DockerContainerConfig):
         self,
         name: str,
         probe_type: Type["Probe"],
+        payment_config: PaymentConfig,
         volumes: Optional[Dict[Path, str]] = None,
         log_config: Optional[LogConfig] = None,
         environment: Optional[Dict[str, str]] = None,
@@ -60,6 +62,7 @@ class YagnaContainerConfig(DockerContainerConfig):
     ):
         super().__init__(name, volumes or {}, log_config, privileged_mode)
         self.probe_type = probe_type
+        self.payment_config = payment_config
         self.probe_properties = probe_properties or {}
         self.environment = environment or {}
         self.payment_id = payment_id

--- a/goth/runner/probe/__init__.py
+++ b/goth/runner/probe/__init__.py
@@ -445,8 +445,9 @@ class RequestorProbe(ActivityApiMixin, MarketApiMixin, PaymentApiMixin, Probe):
     async def _start_container(self) -> None:
         await super()._start_container()
 
-        self.cli.payment_fund()
-        self.cli.payment_init(sender_mode=True)
+        payment_driver = self._yagna_config.payment_config.driver
+        self.cli.payment_fund(payment_driver)
+        self.cli.payment_init(payment_driver, sender_mode=True)
 
 
 class ProviderProbe(MarketApiMixin, PaymentApiMixin, Probe):

--- a/test/integration/test_payment_platform.py
+++ b/test/integration/test_payment_platform.py
@@ -5,17 +5,17 @@ import pytest
 from goth.configuration import load_yaml
 
 EXPECTED_PAYMENT_ENV = {
-    'polygon': {
+    "polygon": {
         "YA_PAYMENT_NETWORK": "polygon",
         "POLYGON_GETH_ADDR": "http://ethereum:8545",
         "POLYGON_GLM_CONTRACT_ADDRESS": "0xFDFEF9D10d929cB3905C71400ce6be1990EA0F34",
     },
-    'zksync': {
+    "zksync": {
         "YA_PAYMENT_NETWORK": "rinkeby",
         "ZKSYNC_RINKEBY_RPC_ADDRESS": "http://zksync:3030",
         "ZKSYNC_FAUCET_ADDR": "http://zksync:3030/zk/donatex",
     },
-    'erc20': {
+    "erc20": {
         "YA_PAYMENT_NETWORK": "mainnet",
         "MAINNET_GETH_ADDR": "http://ethereum:8545",
         "MAINNET_GLM_CONTRACT_ADDRESS": "0xFDFEF9D10d929cB3905C71400ce6be1990EA0F34",
@@ -34,7 +34,7 @@ async def test_default_payment_platform(default_goth_config: Path) -> None:
             assert env[key] == val
 
 
-@pytest.mark.parametrize('payments_name', ('zksync', 'erc20', 'polygon'))
+@pytest.mark.parametrize("payments_name", ("zksync", "erc20", "polygon"))
 @pytest.mark.asyncio
 async def test_payment_platform_env(default_goth_config: Path, payments_name) -> None:
     """Test if "payments" param in config file works."""
@@ -44,12 +44,7 @@ async def test_payment_platform_env(default_goth_config: Path, payments_name) ->
         "use-proxy": True,
         "payments": payments_name,
     }
-    overrides = [
-        (
-            "nodes",
-            [requestor_node]
-        )
-    ]
+    overrides = [("nodes", [requestor_node])]
     goth_config = load_yaml(default_goth_config, overrides)
     requestor_container = goth_config.containers[0]
 
@@ -69,11 +64,6 @@ async def test_invalid_payments_name(default_goth_config: Path) -> None:
         "use-proxy": True,
         "payments": "OOOOPS_NO_SUCH_CONFIG",
     }
-    overrides = [
-        (
-            "nodes",
-            [requestor_node]
-        )
-    ]
+    overrides = [("nodes", [requestor_node])]
     with pytest.raises(KeyError):
         load_yaml(default_goth_config, overrides)

--- a/test/integration/test_payment_platform.py
+++ b/test/integration/test_payment_platform.py
@@ -1,4 +1,4 @@
-"""Test if "payments" in `goth-config.yml` works as expected."""
+"""Test if "payment_config" in `goth-config.yml` works as expected."""
 from pathlib import Path
 import pytest
 
@@ -34,21 +34,21 @@ async def test_default_payment_platform(default_goth_config: Path) -> None:
             assert env[key] == val
 
 
-@pytest.mark.parametrize("payments_name", ("zksync", "erc20", "polygon"))
+@pytest.mark.parametrize("payment_config", ("zksync", "erc20", "polygon"))
 @pytest.mark.asyncio
-async def test_payment_platform_env(default_goth_config: Path, payments_name) -> None:
-    """Test if "payments" param in config file works."""
+async def test_payment_platform_env(default_goth_config: Path, payment_config) -> None:
+    """Test if "payment_config" param in config file works."""
     requestor_node = {
         "name": "requestor",
         "type": "Requestor",
         "use-proxy": True,
-        "payments": payments_name,
+        "payment_config": payment_config,
     }
     overrides = [("nodes", [requestor_node])]
     goth_config = load_yaml(default_goth_config, overrides)
     requestor_container = goth_config.containers[0]
 
-    expected_payment_env = EXPECTED_PAYMENT_ENV[payments_name]
+    expected_payment_env = EXPECTED_PAYMENT_ENV[payment_config]
     env = requestor_container.environment
 
     for key, val in expected_payment_env.items():
@@ -56,13 +56,13 @@ async def test_payment_platform_env(default_goth_config: Path, payments_name) ->
 
 
 @pytest.mark.asyncio
-async def test_invalid_payments_name(default_goth_config: Path) -> None:
+async def test_invalid_payment_config(default_goth_config: Path) -> None:
     """Test if we get KeyError for invalid payment config name."""
     requestor_node = {
         "name": "requestor",
         "type": "Requestor",
         "use-proxy": True,
-        "payments": "OOOOPS_NO_SUCH_CONFIG",
+        "payment_config": "OOOOPS_NO_SUCH_CONFIG",
     }
     overrides = [("nodes", [requestor_node])]
     with pytest.raises(KeyError):

--- a/test/integration/test_payment_platform.py
+++ b/test/integration/test_payment_platform.py
@@ -10,8 +10,8 @@ EXPECTED_PAYMENT_ENV = {
         "POLYGON_GLM_CONTRACT_ADDRESS": "0xFDFEF9D10d929cB3905C71400ce6be1990EA0F34",
     },
     'zksync': {
-        "YA_PAYMENT_NETWORK": "mainnet",
-        "ZKSYNC_MAINNET_RPC_ADDRESS": "http://zksync:3030",
+        "YA_PAYMENT_NETWORK": "rinkeby",
+        "ZKSYNC_RINKEBY_RPC_ADDRESS": "http://zksync:3030",
         "ZKSYNC_FAUCET_ADDR": "http://zksync:3030/zk/donatex",
     },
     'mainnet': {

--- a/test/integration/test_payment_platform.py
+++ b/test/integration/test_payment_platform.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+import pytest
+
+from goth.configuration import load_yaml
+
+EXPECTED_PAYMENT_ENV = {
+    'polygon': {
+        "MUMBAI_TGLM_CONTRACT_ADDRESS": "0xFDFEF9D10d929cB3905C71400ce6be1990EA0F34",
+        "MUMBAI_GETH_ADDR": "http://ethereum:8545",
+        "YA_PAYMENT_NETWORK": "mumbai",
+    },
+    'zksync': {
+        #   TODO: leave only variables we need
+
+        # TODO: Remove after 0.7.x is released, 0.6.x still requires it to be compatible
+        "ERC20_RINKEBY_GETH_ADDR": "http://ethereum:8545",
+
+        "RINKEBY_GETH_ADDR": "http://ethereum:8545",
+        "RINKEBY_TGLM_CONTRACT_ADDRESS": "0xFDFEF9D10d929cB3905C71400ce6be1990EA0F34",
+        "YA_PAYMENT_NETWORK": "rinkeby",
+        "ZKSYNC_FAUCET_ADDR": "http://zksync:3030/zk/donatex",
+        "ZKSYNC_RINKEBY_RPC_ADDRESS": "http://zksync:3030",
+
+        # left for compatibility with yagna prior to commit 800efe13
+        "ZKSYNC_RPC_ADDRESS": "http://zksync:3030",
+    }
+}
+
+
+@pytest.mark.asyncio
+async def test_payment_platform(default_goth_config: Path, log_dir: Path) -> None:
+    overrides = [
+        (
+            "nodes",
+            [
+                {"name": "requestor", "type": "Requestor", "use-proxy": True},
+                {"name": "provider-1", "type": "VM-Wasm-Provider", "use-proxy": True,
+                    "payments": "zksync"},
+                {"name": "provider-2", "type": "VM-Wasm-Provider", "use-proxy": True,
+                    "payments": "polygon"},
+            ],
+        )
+    ]
+    goth_config = load_yaml(default_goth_config, overrides)
+    for container in goth_config.containers:
+        if container.name == 'provider-2':
+            payments = 'polygon'
+        else:
+            payments = "zksync"
+
+        expected_payment_env = EXPECTED_PAYMENT_ENV[payments]
+        env = container.environment
+
+        for key, val in expected_payment_env.items():
+            assert env[key] == val

--- a/test/integration/test_payment_platform.py
+++ b/test/integration/test_payment_platform.py
@@ -1,3 +1,4 @@
+"""Test if "payments" in `goth-config.yml` works as expected."""
 from pathlib import Path
 import pytest
 
@@ -24,6 +25,7 @@ EXPECTED_PAYMENT_ENV = {
 
 @pytest.mark.asyncio
 async def test_default_payment_platform(default_goth_config: Path) -> None:
+    """Test if we have "zksync" platform when none is specified."""
     goth_config = load_yaml(default_goth_config)
     for container in goth_config.containers:
         expected_payment_env = EXPECTED_PAYMENT_ENV["zksync"]
@@ -35,6 +37,7 @@ async def test_default_payment_platform(default_goth_config: Path) -> None:
 @pytest.mark.parametrize('payments_name', ('zksync', 'erc20', 'polygon'))
 @pytest.mark.asyncio
 async def test_payment_platform_env(default_goth_config: Path, payments_name) -> None:
+    """Test if "payments" param in config file works."""
     requestor_node = {
         "name": "requestor",
         "type": "Requestor",
@@ -55,3 +58,22 @@ async def test_payment_platform_env(default_goth_config: Path, payments_name) ->
 
     for key, val in expected_payment_env.items():
         assert env[key] == val
+
+
+@pytest.mark.asyncio
+async def test_invalid_payments_name(default_goth_config: Path) -> None:
+    """Test if we get KeyError for invalid payment config name."""
+    requestor_node = {
+        "name": "requestor",
+        "type": "Requestor",
+        "use-proxy": True,
+        "payments": "OOOOPS_NO_SUCH_CONFIG",
+    }
+    overrides = [
+        (
+            "nodes",
+            [requestor_node]
+        )
+    ]
+    with pytest.raises(KeyError):
+        load_yaml(default_goth_config, overrides)

--- a/test/integration/test_payment_platform.py
+++ b/test/integration/test_payment_platform.py
@@ -42,7 +42,7 @@ async def test_payment_platform_env(default_goth_config: Path, payment_config) -
         "name": "requestor",
         "type": "Requestor",
         "use-proxy": True,
-        "payment_config": payment_config,
+        "payment-config": payment_config,
     }
     overrides = [("nodes", [requestor_node])]
     goth_config = load_yaml(default_goth_config, overrides)
@@ -62,7 +62,7 @@ async def test_invalid_payment_config(default_goth_config: Path) -> None:
         "name": "requestor",
         "type": "Requestor",
         "use-proxy": True,
-        "payment_config": "OOOOPS_NO_SUCH_CONFIG",
+        "payment-config": "OOOOPS_NO_SUCH_CONFIG",
     }
     overrides = [("nodes", [requestor_node])]
     with pytest.raises(KeyError):

--- a/test/integration/test_payment_platform.py
+++ b/test/integration/test_payment_platform.py
@@ -5,25 +5,20 @@ from goth.configuration import load_yaml
 
 EXPECTED_PAYMENT_ENV = {
     'polygon': {
-        "MUMBAI_TGLM_CONTRACT_ADDRESS": "0xFDFEF9D10d929cB3905C71400ce6be1990EA0F34",
-        "MUMBAI_GETH_ADDR": "http://ethereum:8545",
-        "YA_PAYMENT_NETWORK": "mumbai",
+        "YA_PAYMENT_NETWORK": "polygon",
+        "POLYGON_GETH_ADDR": "http://ethereum:8545",
+        "POLYGON_GLM_CONTRACT_ADDRESS": "0xFDFEF9D10d929cB3905C71400ce6be1990EA0F34",
     },
     'zksync': {
-        #   TODO: leave only variables we need
-
-        # TODO: Remove after 0.7.x is released, 0.6.x still requires it to be compatible
-        "ERC20_RINKEBY_GETH_ADDR": "http://ethereum:8545",
-
-        "RINKEBY_GETH_ADDR": "http://ethereum:8545",
-        "RINKEBY_TGLM_CONTRACT_ADDRESS": "0xFDFEF9D10d929cB3905C71400ce6be1990EA0F34",
-        "YA_PAYMENT_NETWORK": "rinkeby",
+        "YA_PAYMENT_NETWORK": "mainnet",
+        "ZKSYNC_MAINNET_RPC_ADDRESS": "http://zksync:3030",
         "ZKSYNC_FAUCET_ADDR": "http://zksync:3030/zk/donatex",
-        "ZKSYNC_RINKEBY_RPC_ADDRESS": "http://zksync:3030",
-
-        # left for compatibility with yagna prior to commit 800efe13
-        "ZKSYNC_RPC_ADDRESS": "http://zksync:3030",
-    }
+    },
+    'mainnet': {
+        "YA_PAYMENT_NETWORK": "mainnet",
+        "MAINNET_GETH_ADDR": "http://ethereum:8545",
+        "MAINNET_GLM_CONTRACT_ADDRESS": "0xFDFEF9D10d929cB3905C71400ce6be1990EA0F34",
+    },
 }
 
 

--- a/test/unit/runner/cli/test_yagna_payment_cmd.py
+++ b/test/unit/runner/cli/test_yagna_payment_cmd.py
@@ -8,7 +8,7 @@ def test_payment_init(yagna_container):
 
     yagna = Cli(yagna_container).yagna
 
-    yagna.payment_init()
+    yagna.payment_init("zksync")
 
 
 def test_payment_init_provider_mode(yagna_container):
@@ -16,7 +16,7 @@ def test_payment_init_provider_mode(yagna_container):
 
     yagna = Cli(yagna_container).yagna
 
-    yagna.payment_init(receiver_mode=True)
+    yagna.payment_init("zksync", receiver_mode=True)
 
 
 def test_payment_init_requestor_mode(yagna_container):
@@ -24,7 +24,7 @@ def test_payment_init_requestor_mode(yagna_container):
 
     yagna = Cli(yagna_container).yagna
 
-    yagna.payment_init(sender_mode=True)
+    yagna.payment_init("zksync", sender_mode=True)
 
 
 def test_payment_status(yagna_container):
@@ -32,7 +32,7 @@ def test_payment_status(yagna_container):
 
     yagna = Cli(yagna_container).yagna
 
-    status = yagna.payment_status()
+    status = yagna.payment_status("zksync")
     assert status
 
 
@@ -41,5 +41,5 @@ def test_payment_status_with_address(yagna_container):
 
     yagna = Cli(yagna_container).yagna
 
-    status = yagna.payment_status()
+    status = yagna.payment_status("zksync")
     assert status

--- a/test/unit/runner/container/test_payment.py
+++ b/test/unit/runner/container/test_payment.py
@@ -4,9 +4,9 @@ import pytest
 
 from goth.runner.container.payment import (
     KeyPoolDepletedError,
-    PaymentDriver,
     PaymentIdPool,
 )
+from goth.payment_config import get_payment_config
 
 
 @pytest.fixture
@@ -15,29 +15,30 @@ def payment_id_pool() -> PaymentIdPool:
     return PaymentIdPool()
 
 
-def test_get_id(payment_id_pool):
+@pytest.mark.parametrize("payment_config_name", ("erc20", "zksync"))
+def test_get_id(payment_id_pool, payment_config_name):
     """Test if pre-funded payment accounts are generated correctly."""
-    drivers = [PaymentDriver.erc20, PaymentDriver.zksync]
     receive = False
     send = False
 
-    payment_id = payment_id_pool.get_id(drivers, receive, send)
+    payment_config = get_payment_config(payment_config_name)
+    payment_id = payment_id_pool.get_id(payment_config, receive, send)
 
-    # We should get back exactly 2 accounts
-    assert len(payment_id.accounts) == len(drivers)
-    # There should be an account for each of the requested payment drivers
-    result_drivers = [a.driver for a in payment_id.accounts]
-    for driver in drivers:
-        assert driver in result_drivers
-    # All accounts should have the requested receive/send values
-    for account in payment_id.accounts:
-        assert account.receive == receive
-        assert account.send == send
+    assert len(payment_id.accounts) == 1
+
+    account = payment_id.accounts[0]
+
+    assert account.driver == payment_config.driver
+    assert account.token == payment_config.token
+    assert account.network == payment_config.network
+    assert account.receive == receive
+    assert account.send == send
 
 
 def test_key_pool_depleted(payment_id_pool):
     """Test if the proper exception is raised when we run out of pre-funded keys."""
 
+    any_payment_config = get_payment_config("zksync")
     with pytest.raises(KeyPoolDepletedError):
         while True:
-            payment_id_pool.get_id()
+            payment_id_pool.get_id(any_payment_config)

--- a/test/unit/runner/test_shutdown.py
+++ b/test/unit/runner/test_shutdown.py
@@ -38,7 +38,7 @@ topology = [
     YagnaContainerConfig(
         name="requestor",
         probe_type=Probe,
-        payment_config=get_payment_config('zksync'),
+        payment_config=get_payment_config("zksync"),
         volumes={},
         environment={},
         payment_id=mock.MagicMock(),
@@ -46,7 +46,7 @@ topology = [
     YagnaContainerConfig(
         name="provider",
         probe_type=Probe,
-        payment_config=get_payment_config('zksync'),
+        payment_config=get_payment_config("zksync"),
         volumes={},
         environment={},
         privileged_mode=False,

--- a/test/unit/runner/test_shutdown.py
+++ b/test/unit/runner/test_shutdown.py
@@ -15,6 +15,7 @@ from goth.runner.container.yagna import YagnaContainerConfig
 from goth.runner.probe import Probe
 from goth.runner.proxy import Proxy
 from goth.runner.web_server import WebServer
+from goth.payment_config import get_payment_config
 
 
 TestFailure.__test__ = False
@@ -37,6 +38,7 @@ topology = [
     YagnaContainerConfig(
         name="requestor",
         probe_type=Probe,
+        payment_config=get_payment_config('zksync'),
         volumes={},
         environment={},
         payment_id=mock.MagicMock(),
@@ -44,6 +46,7 @@ topology = [
     YagnaContainerConfig(
         name="provider",
         probe_type=Probe,
+        payment_config=get_payment_config('zksync'),
         volumes={},
         environment={},
         privileged_mode=False,


### PR DESCRIPTION
Resolves https://github.com/golemfactory/goth/issues/554

VISIBLE CHANGES:
1. Every node in `goth-config.yml` has optional key "payments" with a payment config name. Allowed names are now "erc20", "zksync" and "polygon". If "payments" is not specified, default value "zksync" will be used.
2. All nodes initialize only a **single** payment driver (up to now, both `zksync` and `erc20` were initialized). This shouldn't be hard to change if we want it one day.

INTERNAL CHANGES:
1. All payment-related configuration is in a single place, there are no defaults anywhere outside of `goth/payment_config.py`. This required some additional args here and there.
2. I removed `PaymentDriver` enum - I think it's not really useful after the change in previous point. I'm not 100% sure about this, but if we want it back than why not also `PaymentNetwork` enum?
3. There was some cleanup of env variables - now only those necessary should be set (at least regarding payments).

NOTE: The only thing I checked (outside of the `goth` repo) is that:
* test_run_blender (in `yapapi`) works with this version
* after adding `payments: erc20` in `goth-config.yml` in `yapapi` tests we need ` --payment-driver erc20 --payment-network mainnet` in `test_run_blender`
* if only one provider has `payments: erc20`, blender uses only this provider

And as far as I understand, this is what we wanted.

Recommended reading start: `goth/payment_config.py`.
Also, commits are messy, there's no use in reading them one by one.