### PR TITLE
Increase timeout for collect proposals to 30s

### DIFF
--- a/goth/runner/probe/mixin.py
+++ b/goth/runner/probe/mixin.py
@@ -181,7 +181,7 @@ class MarketApiMixin:
         """Call wait_for_approval on the market api."""
         await self.api.market.wait_for_approval(agreement_id)
 
-    @step()
+    @step(30.0)
     async def wait_for_proposals(
         self: ProbeProtocol,
         subscription_id: str,


### PR DESCRIPTION
Tests are failing when broadcasts overlap, increase timeout so more (~10) broadcasts are made before the time is up.