### PR TITLE
change default payments to (erc20, rinkeby)

### DIFF
--- a/goth/configuration.py
+++ b/goth/configuration.py
@@ -16,7 +16,7 @@ from goth.node import node_environment
 from goth.runner.probe import Probe, YagnaContainerConfig
 from goth.payment_config import get_payment_config, PaymentConfig
 
-DEFAULT_PAYMENT_CONFIG_NAME = "zksync"
+DEFAULT_PAYMENT_CONFIG_NAME = "erc20"
 """Determines PaymentConfig object that will be used for containers
 without specified "payment-config" """
 

--- a/goth/payment_config.py
+++ b/goth/payment_config.py
@@ -20,7 +20,7 @@ _payment_config = {
         "network": "rinkeby",
         "token": "tGLM",
     },
-    "erc20": {
+    "erc20_mainnet": {
         "env": {
             "ERC20_MAINNET_REQUIRED_CONFIRMATIONS": REQUIRED_CONFIRMATIONS_COUNT,
             "MAINNET_GETH_ADDR": GETH_ADDR,
@@ -30,6 +30,17 @@ _payment_config = {
         "driver": "erc20",
         "network": "mainnet",
         "token": "GLM",
+    },
+    "erc20": {
+        "env": {
+            "ERC20_RINKEBY_REQUIRED_CONFIRMATIONS": REQUIRED_CONFIRMATIONS_COUNT,
+            "RINKEBY_GETH_ADDR": GETH_ADDR,
+            "RINKEBY_TGLM_CONTRACT_ADDRESS": GLM_CONTRACT_ADDRESS,
+            "YA_PAYMENT_NETWORK": "rinkeby",
+        },
+        "driver": "erc20",
+        "network": "rinkeby",
+        "token": "tGLM",
     },
     "polygon": {
         "env": {

--- a/test/integration/test_payment_platform.py
+++ b/test/integration/test_payment_platform.py
@@ -15,26 +15,35 @@ EXPECTED_PAYMENT_ENV = {
         "ZKSYNC_RINKEBY_RPC_ADDRESS": "http://zksync:3030",
         "ZKSYNC_FAUCET_ADDR": "http://zksync:3030/zk/donatex",
     },
-    "erc20": {
+    "erc20_mainnet": {
         "YA_PAYMENT_NETWORK": "mainnet",
         "MAINNET_GETH_ADDR": "http://ethereum:8545",
         "MAINNET_GLM_CONTRACT_ADDRESS": "0xFDFEF9D10d929cB3905C71400ce6be1990EA0F34",
+        "ERC20_MAINNET_REQUIRED_CONFIRMATIONS": 0,
+    },
+    "erc20": {
+        "YA_PAYMENT_NETWORK": "rinkeby",
+        "RINKEBY_GETH_ADDR": "http://ethereum:8545",
+        "RINKEBY_TGLM_CONTRACT_ADDRESS": "0xFDFEF9D10d929cB3905C71400ce6be1990EA0F34",
+        "ERC20_RINKEBY_REQUIRED_CONFIRMATIONS": 0,
     },
 }
 
 
 @pytest.mark.asyncio
 async def test_default_payment_platform(default_goth_config: Path) -> None:
-    """Test if we have "zksync" platform when none is specified."""
+    """Test if we have "erc20" platform when none is specified."""
     goth_config = load_yaml(default_goth_config)
     for container in goth_config.containers:
-        expected_payment_env = EXPECTED_PAYMENT_ENV["zksync"]
+        expected_payment_env = EXPECTED_PAYMENT_ENV["erc20"]
         env = container.environment
         for key, val in expected_payment_env.items():
             assert env[key] == val
 
 
-@pytest.mark.parametrize("payment_config", ("zksync", "erc20", "polygon"))
+@pytest.mark.parametrize(
+    "payment_config", ("zksync", "erc20_mainnet", "erc20", "polygon")
+)
 @pytest.mark.asyncio
 async def test_payment_platform_env(default_goth_config: Path, payment_config) -> None:
     """Test if "payment_config" param in config file works."""


### PR DESCRIPTION
I preserved the old `erc20` config as `erc20_mainnet` because it **might** be useful one day and I already twice had problems with changing one to the other.