### PR TITLE
add option to acquire a process monitor for a command running on a host

### DIFF
--- a/goth/runner/probe/__init__.py
+++ b/goth/runner/probe/__init__.py
@@ -18,7 +18,6 @@ from typing import (
     Optional,
     Tuple,
     TYPE_CHECKING,
-    Union,
 )
 
 from docker import DockerClient
@@ -352,12 +351,8 @@ class Probe(abc.ABC):
         command: str,
         env: Optional[Mapping[str, str]] = None,
         command_timeout: float = 300,
-        get_process_monitor: bool = False,
     ) -> AsyncIterator[
-        Union[
-            Tuple[asyncio.Task, PatternMatchingEventMonitor],
-            Tuple[asyncio.Task, PatternMatchingEventMonitor, process.ProcessMonitor],
-        ]
+        Tuple[asyncio.Task, PatternMatchingEventMonitor, process.ProcessMonitor],
     ]:
         """Run `command` on host in given `env` and with optional `timeout`.
 
@@ -399,10 +394,7 @@ class Probe(abc.ABC):
                         process_monitor=process_monitor,
                     )
                 )
-                yield_content = [cmd_task, cmd_monitor]
-                if get_process_monitor:
-                    yield_content.append(process_monitor)
-                yield yield_content
+                yield cmd_task, cmd_monitor, process_monitor
 
                 await cmd_task
                 logger.debug("Command task has finished")

--- a/goth/runner/process.py
+++ b/goth/runner/process.py
@@ -14,14 +14,18 @@ RUN_COMMAND_DEFAULT_TIMEOUT = 900  # seconds
 
 
 class ProcessMonitor:
+    """Monitor enabling acquisition of the process object of a running command."""
+
     _process: Optional[asyncio.subprocess.Process] = None
 
     async def get_process(self) -> asyncio.subprocess.Process:
+        """Wait for and return the `Process` object."""
         while not self._process:
             await asyncio.sleep(0.1)
         return self._process
 
     def set_process(self, process: asyncio.subprocess.Process):
+        """Set the process object."""
         self._process = process
 
 
@@ -47,8 +51,8 @@ async def run_command(
     :param log_prefix: prefix for log lines with command output; ignored if `cmd_logger`
         is specified. Default: name of the command
     :param timeout: timeout for the command, in seconds. Default: 15 minutes
-    :param process_monitor: and optional `ProcessMonitor` to which the spawned process will be
-        reported, so that it can be communicated with from the calling code
+    :param process_monitor: and optional `ProcessMonitor` to which the spawned process
+        will be reported, so that it can be communicated with from the calling code
     """
     logger.info("Running local command: %s", " ".join(args))
 

--- a/goth/runner/process.py
+++ b/goth/runner/process.py
@@ -24,10 +24,6 @@ class ProcessMonitor:
             await asyncio.sleep(0.1)
         return self._process
 
-    def set_process(self, process: asyncio.subprocess.Process):
-        """Set the process object."""
-        self._process = process
-
 
 async def run_command(
     args: Sequence[str],
@@ -51,7 +47,7 @@ async def run_command(
     :param log_prefix: prefix for log lines with command output; ignored if `cmd_logger`
         is specified. Default: name of the command
     :param timeout: timeout for the command, in seconds. Default: 15 minutes
-    :param process_monitor: and optional `ProcessMonitor` to which the spawned process
+    :param process_monitor: an optional `ProcessMonitor` to which the spawned process
         will be reported, so that it can be communicated with from the calling code
     """
     logger.info("Running local command: %s", " ".join(args))
@@ -69,7 +65,7 @@ async def run_command(
         )
 
         if process_monitor:
-            process_monitor.set_process(proc)
+            process_monitor._process = proc
 
         while not proc.stdout.at_eof():
             line = await proc.stdout.readline()

--- a/test/unit/runner/probe/test_run_command_on_host.py
+++ b/test/unit/runner/probe/test_run_command_on_host.py
@@ -1,4 +1,5 @@
 """Tests for the method Probe.run_command_on_host."""
+import asyncio
 import os
 import pytest
 from unittest.mock import MagicMock
@@ -7,16 +8,28 @@ from goth.address import YAGNA_BUS_URL, YAGNA_REST_URL, YAGNA_REST_PORT
 import goth.runner.container.yagna
 from goth.runner.probe import RequestorProbe
 
+CONTAINER_REST_PORT = 6006
 
-@pytest.mark.asyncio
-async def test_run_command_on_host(monkeypatch):
-    """Test if the method `run_command_on_host` works as expected."""
+
+async def env_lines_to_dict(lines):
+    """Convert the lines received from the `env` command into a dictionary."""
+    # The monitor should guarantee that we don't skip any events
+    assert len(lines.past_events) == 0, lines.past_events
+    env = {}
+    async for line in lines:
+        tokens = line.split("=", 1)
+        if len(tokens) == 2:
+            env[tokens[0]] = tokens[1]
+    return env
+
+
+def mock_probe(monkeypatch):
+    """Get a mocked `RequestorProbe`."""
 
     runner = MagicMock()
     docker_client = MagicMock()
     container_config = MagicMock(use_proxy=False)
     log_config = MagicMock()
-    container_rest_port = 6006
 
     monkeypatch.setattr(goth.runner.probe, "YagnaContainer", MagicMock(spec="ports"))
     monkeypatch.setattr(goth.runner.probe, "Cli", MagicMock(spec="yagna"))
@@ -28,29 +41,31 @@ async def test_run_command_on_host(monkeypatch):
         config=container_config,
         log_config=log_config,
     )
-    probe.container.ports = {YAGNA_REST_PORT: container_rest_port}
+    probe.container.ports = {YAGNA_REST_PORT: CONTAINER_REST_PORT}
+    return probe
 
-    async def func(lines):
-        # The monitor should guarantee that we don't skip any events
-        assert len(lines.past_events) == 0, lines.past_events
-        env = {}
-        async for line in lines:
-            tokens = line.split("=", 1)
-            if len(tokens) == 2:
-                env[tokens[0]] = tokens[1]
-        return env
+
+@pytest.mark.asyncio
+async def test_run_command_on_host(monkeypatch):
+    """Test if the method `run_command_on_host` works as expected."""
+
+    probe = mock_probe(monkeypatch)
 
     async with probe.run_command_on_host(
         "/usr/bin/env",
         env=os.environ,
-    ) as (_task, monitor):
-        assertion = monitor.add_assertion(func)
+        get_process_monitor=True,
+    ) as (_task, monitor, process_monitor):
+        assertion = monitor.add_assertion(env_lines_to_dict)
+        proc: asyncio.subprocess.Process = await process_monitor.get_process()
+
+    assert await proc.wait() == 0
 
     result = await assertion.wait_for_result(timeout=1)
 
     assert result["YAGNA_APPKEY"] == probe.app_key
     assert result["YAGNA_API_URL"] == YAGNA_REST_URL.substitute(
-        host="127.0.0.1", port=container_rest_port
+        host="127.0.0.1", port=CONTAINER_REST_PORT
     )
     assert result["GSB_URL"] == YAGNA_BUS_URL.substitute(host=None)
 

--- a/test/unit/runner/probe/test_run_command_on_host.py
+++ b/test/unit/runner/probe/test_run_command_on_host.py
@@ -23,6 +23,7 @@ async def env_lines_to_dict(lines):
     return env
 
 
+@pytest.fixture
 def mock_probe(monkeypatch):
     """Get a mocked `RequestorProbe`."""
 
@@ -46,12 +47,10 @@ def mock_probe(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_run_command_on_host(monkeypatch):
+async def test_run_command_on_host(mock_probe):
     """Test if the method `run_command_on_host` works as expected."""
 
-    probe = mock_probe(monkeypatch)
-
-    async with probe.run_command_on_host(
+    async with mock_probe.run_command_on_host(
         "/usr/bin/env",
         env=os.environ,
     ) as (_task, monitor, process_monitor):
@@ -62,7 +61,7 @@ async def test_run_command_on_host(monkeypatch):
 
     result = await assertion.wait_for_result(timeout=1)
 
-    assert result["YAGNA_APPKEY"] == probe.app_key
+    assert result["YAGNA_APPKEY"] == mock_probe.app_key
     assert result["YAGNA_API_URL"] == YAGNA_REST_URL.substitute(
         host="127.0.0.1", port=CONTAINER_REST_PORT
     )
@@ -70,7 +69,7 @@ async def test_run_command_on_host(monkeypatch):
 
     # Let's make sure that another command can be run without problems
     # (see https://github.com/golemfactory/goth/issues/484).
-    async with probe.run_command_on_host("/bin/echo eChO", env=os.environ) as (
+    async with mock_probe.run_command_on_host("/bin/echo eChO", env=os.environ) as (
         _task,
         monitor,
         _process_monitor,

--- a/test/unit/runner/probe/test_run_command_on_host.py
+++ b/test/unit/runner/probe/test_run_command_on_host.py
@@ -54,7 +54,6 @@ async def test_run_command_on_host(monkeypatch):
     async with probe.run_command_on_host(
         "/usr/bin/env",
         env=os.environ,
-        get_process_monitor=True,
     ) as (_task, monitor, process_monitor):
         assertion = monitor.add_assertion(env_lines_to_dict)
         proc: asyncio.subprocess.Process = await process_monitor.get_process()
@@ -74,6 +73,7 @@ async def test_run_command_on_host(monkeypatch):
     async with probe.run_command_on_host("/bin/echo eChO", env=os.environ) as (
         _task,
         monitor,
+        _process_monitor,
     ):
 
         await monitor.wait_for_pattern(".*eChO", timeout=10)


### PR DESCRIPTION
the underlying need is that if you e.g. want to send a SIGINT to the command that you have launched, there's no way to do that sensibly if you don't have access to the process