### PR TITLE
Goth - optimize docker build

### DIFF
--- a/goth/default-assets/docker/yagna-goth-deb.Dockerfile
+++ b/goth/default-assets/docker/yagna-goth-deb.Dockerfile
@@ -1,9 +1,12 @@
 # debian:bullseye-slim, 2021-05-12
 FROM debian@sha256:e827c9bc6913625ec75c8b466e6e79a6b936d0801956be607bce08a07078f57a
-COPY deb/* ./
-RUN chmod +x /usr/bin/* \
-    && apt update \
-    && yes | apt install -y ./*.deb \
+
+RUN apt update \
     && apt install -y libssl-dev ca-certificates \
     && update-ca-certificates
+
+COPY deb/* ./
+RUN chmod +x /usr/bin/* \
+    && yes | apt install -y ./*.deb
+
 ENTRYPOINT /usr/bin/yagna

--- a/goth/default-assets/docker/yagna-goth.Dockerfile
+++ b/goth/default-assets/docker/yagna-goth.Dockerfile
@@ -1,11 +1,15 @@
 # debian:bullseye-slim, 2021-05-12
 FROM debian@sha256:e827c9bc6913625ec75c8b466e6e79a6b936d0801956be607bce08a07078f57a
+
+RUN apt update \
+    && apt install -y libssl-dev ca-certificates \
+    && update-ca-certificates
+
 COPY deb/* ./
 COPY bin/* /usr/bin/
+
 RUN chmod +x /usr/bin/* \
-    && apt update \
     && apt install -y ./*.deb \
-    && apt install -y libssl-dev ca-certificates \
-    && update-ca-certificates \
     && ln -s /usr/bin/exe-unit /usr/lib/yagna/plugins/exe-unit
+
 ENTRYPOINT /usr/bin/yagna


### PR DESCRIPTION
Openssl installation can be executed before installing .debs or binaries, so thanks to docker cache, building images should be faster