### PR TITLE
Update cert ids in cert-permissions.json

### DIFF
--- a/goth/default-assets/provider/cert-dir/cert-permissions.json
+++ b/goth/default-assets/provider/cert-dir/cert-permissions.json
@@ -1,9 +1,9 @@
 {
-  "4e0df976": [
+  "fe4f04e2517488ba32acd4354fca66fd67b4078722fcd1a17a1487b7723477b62af2f17fa35c9b329b52658ccfbbe663c64c3fdf4378519d9279c13e88f7bb99": [
     "outbound-manifest",
     "unverified-permissions-chain"
   ],
-  "c128af8c": [
+  "55e451bd1a2f43570a25052b863af1d527fe6fd4bfd1482fdb241596432477f20eb2b2f3801fb5c6cd785f1a03c43ccf71fd8cdf0a974d1296be2326b0824673": [
     "outbound-manifest",
     "unverified-permissions-chain"
   ]


### PR DESCRIPTION
This is due to changed calculation of certificate ids in the provider keystore.