### PR TITLE
set default chosen-platform

### DIFF
--- a/goth/runner/probe/mixin.py
+++ b/goth/runner/probe/mixin.py
@@ -154,6 +154,7 @@ class MarketApiMixin:
                 ),
                 "golem.srv.comp.task_package": task_package,
                 "golem.node.debug.subnet": DEFAULT_SUBNET,
+                "golem.com.payment.chosen-platform": self.payment_config.platform_string,
             },
             constraints=constraints,
         )

--- a/goth/runner/probe/mixin.py
+++ b/goth/runner/probe/mixin.py
@@ -138,6 +138,7 @@ class MarketApiMixin:
     async def subscribe_demand(self: ProbeProtocol, demand: Demand) -> Tuple[str, Demand]:
         """Call subscribe demand on the market api."""
         subscription_id = await self.api.market.subscribe_demand(demand)
+        logger.debug("Subscribe demand.")
         return subscription_id, demand
 
     @step()
@@ -158,6 +159,8 @@ class MarketApiMixin:
             },
             constraints=constraints,
         )
+
+        logger.debug("Subscribe template demand.")
 
         return await self.subscribe_demand(demand)  # type: ignore
 

--- a/goth/runner/probe/mixin.py
+++ b/goth/runner/probe/mixin.py
@@ -138,7 +138,6 @@ class MarketApiMixin:
     async def subscribe_demand(self: ProbeProtocol, demand: Demand) -> Tuple[str, Demand]:
         """Call subscribe demand on the market api."""
         subscription_id = await self.api.market.subscribe_demand(demand)
-        logger.debug("Subscribe demand: %s.", demand)
         return subscription_id, demand
 
     @step()
@@ -159,8 +158,6 @@ class MarketApiMixin:
             },
             constraints=constraints,
         )
-
-        logger.debug("Subscribe template demand.")
 
         return await self.subscribe_demand(demand)  # type: ignore
 

--- a/goth/runner/probe/mixin.py
+++ b/goth/runner/probe/mixin.py
@@ -138,7 +138,7 @@ class MarketApiMixin:
     async def subscribe_demand(self: ProbeProtocol, demand: Demand) -> Tuple[str, Demand]:
         """Call subscribe demand on the market api."""
         subscription_id = await self.api.market.subscribe_demand(demand)
-        logger.debug("Subscribe demand.")
+        logger.debug("Subscribe demand: %s.", demand)
         return subscription_id, demand
 
     @step()


### PR DESCRIPTION
Yagna requires `golem.com.payment.chosen-platform` to be set and will not default to `erc20-rinkeby-tglm` anymore.